### PR TITLE
ci: update GitHub Actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Comment Generation Update in PR
         uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
@@ -20,7 +20,7 @@ jobs:
           comment_tag: execution
 
       - name: Set up Python
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10.x'
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/heads/main')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,9 +11,9 @@ jobs:
       # added or changed files to the repository.
       contents: write
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10.x'
       - name: Install dependencies

--- a/fern/apis/master/openapi-overrides.yml
+++ b/fern/apis/master/openapi-overrides.yml
@@ -11,6 +11,17 @@ paths:
     get:
       x-fern-examples:
         - code-samples:
+            - code: 'using Qdrant.Client;
+
+
+                var client = new QdrantClient("localhost", 6334);
+
+
+                await client.ListAliasesAsync();
+
+'
+              language: csharp
+        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
@@ -21,23 +32,6 @@ paths:
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listAliasesAsync().get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\taliases, err := client.ListAliases(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Aliases: \", aliases)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.getAliases();
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -50,43 +44,14 @@ paths:
 '
               language: rust
         - code-samples:
-            - code: 'using Qdrant.Client;
-
-
-                var client = new QdrantClient("localhost", 6334);
-
-
-                await client.ListAliasesAsync();
-
-'
-              language: csharp
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listAliasesAsync().get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\taliases, err := client.ListAliases(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Aliases: \", aliases)\n}\n"
+              language: go
         - code-samples:
             - code: "curl  -X GET \\\n  'http://localhost:6333/aliases' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
-      description: Retrieves a list of all existing aliases.
-      summary: List all aliases
-      tags:
-        - Aliases
-  /collections:
-    get:
-      x-fern-examples:
-        - code-samples:
-            - code: 'from qdrant_client import QdrantClient
-
-
-                client = QdrantClient(url="http://localhost:6333")
-
-
-                client.get_collections()
-
-'
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listCollectionsAsync().get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listCollections() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tcollections, err := client.ListCollections(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collections: \", collections)\n}\n"
-              language: go
         - code-samples:
             - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
 
@@ -94,21 +59,17 @@ paths:
                 const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 
-                client.getCollections();
+                client.getAliases();
 
 '
               language: typescript
-        - code-samples:
-            - code: 'use qdrant_client::Qdrant;
-
-
-                let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-
-                client.list_collections().await?;
-
-'
-              language: rust
+      description: Retrieves a list of all existing aliases.
+      summary: List all aliases
+      tags:
+        - Aliases
+  /collections:
+    get:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -121,8 +82,47 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: 'from qdrant_client import QdrantClient
+
+
+                client = QdrantClient(url="http://localhost:6333")
+
+
+                client.get_collections()
+
+'
+              language: python
+        - code-samples:
+            - code: 'use qdrant_client::Qdrant;
+
+
+                let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+                client.list_collections().await?;
+
+'
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listCollectionsAsync().get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listCollections() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tcollections, err := client.ListCollections(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collections: \", collections)\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X GET \\\n  'http://localhost:6333/collections' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.getCollections();
+
+'
+              language: typescript
       description: Returns a list of all existing collections.
       summary: List all collections
       tags:
@@ -130,21 +130,6 @@ paths:
   /collections/aliases:
     post:
       x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.update_collection_aliases(\n    change_aliases_operations=[\n        models.CreateAliasOperation(\n            create_alias=models.CreateAlias(\n                collection_name=\"example_collection\", alias_name=\"production_collection\"\n            )\n        )\n    ]\n)\n\nclient.update_collection_aliases(\n    change_aliases_operations=[\n        models.DeleteAliasOperation(\n            delete_alias=models.DeleteAlias(alias_name=\"production_collection\")\n        ),\n    ]\n)\n"
-              language: python
-        - code-samples:
-            - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.DeleteShardKey;\nimport io.qdrant.client.grpc.Collections.DeleteShardKeyRequest;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createAliasAsync(\"production_collection\", \"example_collection\").get();\n\nclient.deleteAliasAsync(\"production_collection\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc updateAlias() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.CreateAlias(context.Background(), \"production_collection\", \"example_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteAlias(context.Background(), \"production_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.RenameAlias(context.Background(), \"production_collection\", \"legacy_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateCollectionAliases({\n  actions: [\n    {\n      create_alias: {\n        collection_name: \"example_collection\",\n        alias_name: \"production_collection\",\n      },\n    },\n  ],\n});\n\nclient.updateCollectionAliases({\n  actions: [\n    {\n      delete_alias: {\n        alias_name: \"production_collection\",\n      },\n    },\n  ],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{CreateAliasBuilder, DeleteAlias};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_alias(CreateAliasBuilder::new(\n        \"example_collection\",\n        \"production_collection\",\n    ))\n    .await?;\n\nclient\n    .delete_alias(DeleteAlias {\n        alias_name: \"production_collection\".to_string(),\n    })\n    .await?;\n"
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -160,8 +145,23 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.update_collection_aliases(\n    change_aliases_operations=[\n        models.CreateAliasOperation(\n            create_alias=models.CreateAlias(\n                collection_name=\"example_collection\", alias_name=\"production_collection\"\n            )\n        )\n    ]\n)\n\nclient.update_collection_aliases(\n    change_aliases_operations=[\n        models.DeleteAliasOperation(\n            delete_alias=models.DeleteAlias(alias_name=\"production_collection\")\n        ),\n    ]\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{CreateAliasBuilder, DeleteAlias};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_alias(CreateAliasBuilder::new(\n        \"example_collection\",\n        \"production_collection\",\n    ))\n    .await?;\n\nclient\n    .delete_alias(DeleteAlias {\n        alias_name: \"production_collection\".to_string(),\n    })\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.DeleteShardKey;\nimport io.qdrant.client.grpc.Collections.DeleteShardKeyRequest;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createAliasAsync(\"production_collection\", \"example_collection\").get();\n\nclient.deleteAliasAsync(\"production_collection\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc updateAlias() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.CreateAlias(context.Background(), \"production_collection\", \"example_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteAlias(context.Background(), \"production_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.RenameAlias(context.Background(), \"production_collection\", \"legacy_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "# Create an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n      \"create_alias\": {\n        \"collection_name\": \"{collection_name}\",\n        \"alias_name\": \"{alias_name}\"\n      }\n    }\n  ]\n}'\n\n# Delete an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n      \"delete_alias\": {\n        \"alias_name\": \"{alias_name}\"\n      }\n    }\n  ]\n}'\n\n# Rename an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n      \"rename_alias\": {\n        \"old_alias_name\": \"{old_alias_name}\",\n        \"new_alias_name\": \"{new_alias_name}\"\n      }\n    }\n  ]\n}'\n"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateCollectionAliases({\n  actions: [\n    {\n      create_alias: {\n        collection_name: \"example_collection\",\n        alias_name: \"production_collection\",\n      },\n    },\n  ],\n});\n\nclient.updateCollectionAliases({\n  actions: [\n    {\n      delete_alias: {\n        alias_name: \"production_collection\",\n      },\n    },\n  ],\n});\n"
+              language: typescript
       description: Updates aliases for the specified collections.
       summary: Update collection aliases
       tags:
@@ -169,45 +169,6 @@ paths:
   /collections/{collection_name}:
     delete:
       x-fern-examples:
-        - code-samples:
-            - code: 'from qdrant_client import QdrantClient
-
-
-                client = QdrantClient(url="http://localhost:6333")
-
-
-                client.delete_collection(collection_name="{collection_name}")
-
-'
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteCollectionAsync(\"{collection_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteCollection(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from ''@qdrant/qdrant-js'';
-
-
-                const client = new QdrantClient({url: ''http://127.0.0.1:6333''});
-
-
-                client.deleteCollection("{collection_name}");
-
-'
-              language: typescript
-        - code-samples:
-            - code: 'use qdrant_client::Qdrant;
-
-
-                let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-
-                client.delete_collection("{collection_name}").await?;
-
-'
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -220,42 +181,16 @@ paths:
 '
               language: csharp
         - code-samples:
-            - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
-      description: Drops the specified collection and all associated data in it.
-      summary: Delete a collection
-      tags:
-        - Collections
-    get:
-      x-fern-examples:
-        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
                 client = QdrantClient(url="http://localhost:6333")
 
 
-                client.get_collection("{collection_name}")
+                client.delete_collection(collection_name="{collection_name}")
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.getCollectionInfoAsync(\"{collection_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc getCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tinfo, err := client.GetCollectionInfo(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collection info: \", info)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.getCollection("{collection_name}");
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -263,10 +198,36 @@ paths:
                 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
 
-                client.collection_info("{collection_name}").await?;
+                client.delete_collection("{collection_name}").await?;
 
 '
               language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteCollectionAsync(\"{collection_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteCollection(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
+            - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from ''@qdrant/qdrant-js'';
+
+
+                const client = new QdrantClient({url: ''http://127.0.0.1:6333''});
+
+
+                client.deleteCollection("{collection_name}");
+
+'
+              language: typescript
+      description: Drops the specified collection and all associated data in it.
+      summary: Delete a collection
+      tags:
+        - Collections
+    get:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -279,97 +240,16 @@ paths:
 '
               language: csharp
         - code-samples:
-            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
-      description: Retrieves parameters from the specified collection.
-      summary: Get collection details
-      tags:
-        - Collections
-    patch:
-      x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.update_collection(\n    collection_name=\"{collection_name}\",\n    optimizer_config=models.OptimizersConfigDiff(indexing_threshold=10000),\n)\n"
-              language: python
-        - code-samples:
-            - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.OptimizersConfigDiff;\nimport io.qdrant.client.grpc.Collections.UpdateCollection;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.updateCollectionAsync(\n    UpdateCollection.newBuilder()\n        .setCollectionName(\"{collection_name}\")\n        .setOptimizersConfig(\n            OptimizersConfigDiff.newBuilder().setIndexingThreshold(10000).build())\n        .build());\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc updateCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tthreshold := uint64(10000)\n\terr = client.UpdateCollection(context.Background(), &qdrant.UpdateCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tOptimizersConfig: &qdrant.OptimizersConfigDiff{\n\t\t\tIndexingThreshold: &threshold,\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateCollection(\"{collection_name}\", {\n  optimizers_config: {\n    indexing_threshold: 10000,\n  },\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{OptimizersConfigDiffBuilder, UpdateCollectionBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_collection(\n        UpdateCollectionBuilder::new(\"{collection_name}\").optimizers_config(\n            OptimizersConfigDiffBuilder::default().indexing_threshold(10_000),\n        ),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateCollectionAsync(\n  collectionName: \"{collection_name}\",\n  optimizersConfig: new OptimizersConfigDiff { IndexingThreshold = 10000 }\n);\n"
-              language: csharp
-        - code-samples:
-            - code: "curl  -X PATCH \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"optimizers_config\": {\n    \"indexing_threshold\": 10000\n  }\n}'"
-              language: curl
-      description: Updates the parameters of the specified collection.
-      summary: Update collection parameters
-      tags:
-        - Collections
-    put:
-      x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.create_collection(\n    collection_name=\"{collection_name}\",\n    vectors_config=models.VectorParams(size=100, distance=models.Distance.COSINE),\n)\n"
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.Distance;\nimport io.qdrant.client.grpc.Collections.VectorParams;\n\nQdrantClient client = new QdrantClient(\n    QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createCollectionAsync(\"{collection_name}\",\n        VectorParams.newBuilder().setDistance(Distance.Cosine).setSize(100).build()).get();\n\n// Or with sparse vectors\n\nclient.createCollectionAsync(\n    CreateCollection.newBuilder()\n        .setCollectionName(\"{collection_name}\")\n        .setSparseVectorsConfig(\n            Collections.SparseVectorConfig.newBuilder().putMap(\n                \"splade-model-name\",\n                Collections.SparseVectorParams.newBuilder()\n                    .setIndex(\n                        Collections.SparseIndexConfig\n                            .newBuilder()\n                            .setOnDisk(false)\n                            .build()\n                    ).build()\n            ).build()\n        ).build()\n).get();"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.CreateCollection(context.Background(), &qdrant.CreateCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tVectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{\n\t\t\tSize:     100,\n\t\t\tDistance: qdrant.Distance_Cosine,\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.createCollection(\"{collection_name}\", {\n  vectors: { size: 100, distance: \"Cosine\" },\n});\n\n// or with sparse vectors\n\nclient.createCollection(\"{collection_name}\", {\n  vectors: { size: 100, distance: \"Cosine\" },\n  sparse_vectors: {\n    \"splade-model-name\": {\n      index: {\n        on_disk: false\n      }\n    }\n  }\n});"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_collection(\n        CreateCollectionBuilder::new(\"{collection_name}\")\n            .vectors_config(VectorParamsBuilder::new(100, Distance::Cosine)),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreateCollectionAsync(\n\tcollectionName: \"{collection_name}\",\n\tvectorsConfig: new VectorParams { Size = 100, Distance = Distance.Cosine }\n);\n\n// Or with sparse vectors\n\nawait client.CreateCollectionAsync(\n\tcollectionName: \"{collection_name}\",\n\tsparseVectorsConfig: (\"splade-model-name\", new SparseVectorParams{\n        Index = new SparseIndexConfig {\n            OnDisk = false,\n        }\n    })\n);"
-              language: csharp
-        - code-samples:
-            - code: "# Create a collection with default dense vector\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vectors\": {\n    \"size\": 384,\n    \"distance\": \"Cosine\"\n  }\n}'\n\n# Create a collection with named dense and sparse vectors\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vectors\": {\n    \"dense-vector-name\": {\n      \"size\": 1536,\n      \"distance\": \"Cosine\"\n    }\n  },\n  \"sparse_vectors\": {\n    \"sparse-vector-name\": {\n      \"index\": {\n        \"on_disk\": true\n      }\n    }\n  }\n}'\n"
-              language: curl
-      description: Creates a new collection with the given parameters.
-      summary: Create a collection
-      tags:
-        - Collections
-  /collections/{collection_name}/aliases:
-    get:
-      x-fern-examples:
-        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
                 client = QdrantClient(url="http://localhost:6333")
 
 
-                client.get_collection_aliases("{collection_name}")
+                client.get_collection("{collection_name}")
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listCollectionAliasesAsync(\"{collection_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listCollectionAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\taliases, err := client.ListCollectionAliases(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collection aliases: \", aliases)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.getCollectionAliases("{collection_name}");
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -377,10 +257,91 @@ paths:
                 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
 
-                client.list_collection_aliases("{collection_name}").await?;
+                client.collection_info("{collection_name}").await?;
 
 '
               language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.getCollectionInfoAsync(\"{collection_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc getCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tinfo, err := client.GetCollectionInfo(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collection info: \", info)\n}\n"
+              language: go
+        - code-samples:
+            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.getCollection("{collection_name}");
+
+'
+              language: typescript
+      description: Retrieves parameters from the specified collection.
+      summary: Get collection details
+      tags:
+        - Collections
+    patch:
+      x-fern-examples:
+        - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateCollectionAsync(\n  collectionName: \"{collection_name}\",\n  optimizersConfig: new OptimizersConfigDiff { IndexingThreshold = 10000 }\n);\n"
+              language: csharp
+        - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.update_collection(\n    collection_name=\"{collection_name}\",\n    optimizer_config=models.OptimizersConfigDiff(indexing_threshold=10000),\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{OptimizersConfigDiffBuilder, UpdateCollectionBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_collection(\n        UpdateCollectionBuilder::new(\"{collection_name}\").optimizers_config(\n            OptimizersConfigDiffBuilder::default().indexing_threshold(10_000),\n        ),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.OptimizersConfigDiff;\nimport io.qdrant.client.grpc.Collections.UpdateCollection;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.updateCollectionAsync(\n    UpdateCollection.newBuilder()\n        .setCollectionName(\"{collection_name}\")\n        .setOptimizersConfig(\n            OptimizersConfigDiff.newBuilder().setIndexingThreshold(10000).build())\n        .build());\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc updateCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tthreshold := uint64(10000)\n\terr = client.UpdateCollection(context.Background(), &qdrant.UpdateCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tOptimizersConfig: &qdrant.OptimizersConfigDiff{\n\t\t\tIndexingThreshold: &threshold,\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
+            - code: "curl  -X PATCH \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"optimizers_config\": {\n    \"indexing_threshold\": 10000\n  }\n}'"
+              language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateCollection(\"{collection_name}\", {\n  optimizers_config: {\n    indexing_threshold: 10000,\n  },\n});\n"
+              language: typescript
+      description: Updates the parameters of the specified collection.
+      summary: Update collection parameters
+      tags:
+        - Collections
+    put:
+      x-fern-examples:
+        - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreateCollectionAsync(\n\tcollectionName: \"{collection_name}\",\n\tvectorsConfig: new VectorParams { Size = 100, Distance = Distance.Cosine }\n);\n\n// Or with sparse vectors\n\nawait client.CreateCollectionAsync(\n\tcollectionName: \"{collection_name}\",\n\tsparseVectorsConfig: (\"splade-model-name\", new SparseVectorParams{\n        Index = new SparseIndexConfig {\n            OnDisk = false,\n        }\n    })\n);"
+              language: csharp
+        - code-samples:
+            - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.create_collection(\n    collection_name=\"{collection_name}\",\n    vectors_config=models.VectorParams(size=100, distance=models.Distance.COSINE),\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_collection(\n        CreateCollectionBuilder::new(\"{collection_name}\")\n            .vectors_config(VectorParamsBuilder::new(100, Distance::Cosine)),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.Distance;\nimport io.qdrant.client.grpc.Collections.VectorParams;\n\nQdrantClient client = new QdrantClient(\n    QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createCollectionAsync(\"{collection_name}\",\n        VectorParams.newBuilder().setDistance(Distance.Cosine).setSize(100).build()).get();\n\n// Or with sparse vectors\n\nclient.createCollectionAsync(\n    CreateCollection.newBuilder()\n        .setCollectionName(\"{collection_name}\")\n        .setSparseVectorsConfig(\n            Collections.SparseVectorConfig.newBuilder().putMap(\n                \"splade-model-name\",\n                Collections.SparseVectorParams.newBuilder()\n                    .setIndex(\n                        Collections.SparseIndexConfig\n                            .newBuilder()\n                            .setOnDisk(false)\n                            .build()\n                    ).build()\n            ).build()\n        ).build()\n).get();"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.CreateCollection(context.Background(), &qdrant.CreateCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tVectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{\n\t\t\tSize:     100,\n\t\t\tDistance: qdrant.Distance_Cosine,\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
+            - code: "# Create a collection with default dense vector\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vectors\": {\n    \"size\": 384,\n    \"distance\": \"Cosine\"\n  }\n}'\n\n# Create a collection with named dense and sparse vectors\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vectors\": {\n    \"dense-vector-name\": {\n      \"size\": 1536,\n      \"distance\": \"Cosine\"\n    }\n  },\n  \"sparse_vectors\": {\n    \"sparse-vector-name\": {\n      \"index\": {\n        \"on_disk\": true\n      }\n    }\n  }\n}'\n"
+              language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.createCollection(\"{collection_name}\", {\n  vectors: { size: 100, distance: \"Cosine\" },\n});\n\n// or with sparse vectors\n\nclient.createCollection(\"{collection_name}\", {\n  vectors: { size: 100, distance: \"Cosine\" },\n  sparse_vectors: {\n    \"splade-model-name\": {\n      index: {\n        on_disk: false\n      }\n    }\n  }\n});"
+              language: typescript
+      description: Creates a new collection with the given parameters.
+      summary: Create a collection
+      tags:
+        - Collections
+  /collections/{collection_name}/aliases:
+    get:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -393,8 +354,47 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: 'from qdrant_client import QdrantClient
+
+
+                client = QdrantClient(url="http://localhost:6333")
+
+
+                client.get_collection_aliases("{collection_name}")
+
+'
+              language: python
+        - code-samples:
+            - code: 'use qdrant_client::Qdrant;
+
+
+                let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+                client.list_collection_aliases("{collection_name}").await?;
+
+'
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listCollectionAliasesAsync(\"{collection_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listCollectionAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\taliases, err := client.ListCollectionAliases(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collection aliases: \", aliases)\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/aliases' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.getCollectionAliases("{collection_name}");
+
+'
+              language: typescript
       description: Retrieves a list of all aliases for the specified collection.
       summary: List collection aliases
       tags:
@@ -402,6 +402,17 @@ paths:
   /collections/{collection_name}/exists:
     get:
       x-fern-examples:
+        - code-samples:
+            - code: 'using Qdrant.Client;
+
+
+                var client = new QdrantClient("localhost", 6334);
+
+
+                await client.CollectionExistsAsync("{collection_name}");
+
+'
+              language: csharp
         - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
@@ -411,6 +422,17 @@ paths:
 
                 client.collection_exists(collection_name="{collection_name}")'
               language: python
+        - code-samples:
+            - code: 'use qdrant_client::Qdrant;
+
+
+                let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+                client.collection_exists("{collection_name}").await?;
+
+'
+              language: rust
         - code-samples:
             - code: 'import static io.qdrant.client.ConditionFactory.matchKeyword;
 
@@ -431,6 +453,9 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc collectionExists() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\texists, err := client.CollectionExists(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collection exists: \", exists)\n}\n"
               language: go
         - code-samples:
+            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/exists' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
+        - code-samples:
             - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
 
 
@@ -441,31 +466,6 @@ paths:
 
 '
               language: typescript
-        - code-samples:
-            - code: 'use qdrant_client::Qdrant;
-
-
-                let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-
-                client.collection_exists("{collection_name}").await?;
-
-'
-              language: rust
-        - code-samples:
-            - code: 'using Qdrant.Client;
-
-
-                var client = new QdrantClient("localhost", 6334);
-
-
-                await client.CollectionExistsAsync("{collection_name}");
-
-'
-              language: csharp
-        - code-samples:
-            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/exists' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
       description: Checks whether the specified collection exists.
       summary: Check collection existence
       tags:
@@ -474,8 +474,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.FacetAsync(\n\t\"{collection_name}\",\n\tfilter: MatchKeyword(\"color\", \"red\"),\n\tkey: \"my-payload-key\",\n\tlimit: 10\n);"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.facet(\n    collection_name=\"{collection_name}\",\n    key=\"my-payload-key\",\n    facet_filter=models.Filter(must=[models.Match(\"color\", \"red\")]),\n    limit=10,\n)\n\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, FacetCountsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .facet(\n         FacetCountsBuilder::new(\"{collection_name}\", \"my-payload-key\")\n             .limit(10)\n             .filter(Filter::must(vec![Condition::matches(\n                 \"color\",\n                 \"red\".to_string(),\n             )])),\n     )\n     .await?;"
+              language: rust
         - code-samples:
             - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\nimport io.qdrant.client.grpc.Points;\nimport io.qdrant.client.grpc.Filter;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .facetAsync(\n        Points.FacetCounts.newBuilder()\n            .setCollectionName(collection_name)\n            .setKey(\"my-payload-key\")\n            .setFilter(\n                Filter.newBuilder()\n                    .addMust(matchKeyword(\"color\", \"red\"))\n                    .build())\n            .build())\n        .get();"
               language: java
@@ -485,12 +491,6 @@ paths:
         - code-samples:
             - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.facet(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    key: \"my-payload-key\",\n    limit: 10,\n});\n"
               language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, FacetCountsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .facet(\n         FacetCountsBuilder::new(\"{collection_name}\", \"my-payload-key\")\n             .limit(10)\n             .filter(Filter::must(vec![Condition::matches(\n                 \"color\",\n                 \"red\".to_string(),\n             )])),\n     )\n     .await?;"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.FacetAsync(\n\t\"{collection_name}\",\n\tfilter: MatchKeyword(\"color\", \"red\"),\n\tkey: \"my-payload-key\",\n\tlimit: 10\n);"
-              language: csharp
       description: Retrieves facets for the specified payload field.
       summary: Payload field facets
       tags:
@@ -499,8 +499,14 @@ paths:
     put:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreatePayloadIndexAsync(\n  collectionName: \"{collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.create_payload_index(\n    collection_name=\"{collection_name}\",\n    field_name=\"name_of_the_field_to_index\",\n    field_schema=\"keyword\",\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_field_index(\n        CreateFieldIndexCollectionBuilder::new(\n            \"{collection_name}\",\n            \"{field_name}\",\n            FieldType::Keyword,\n        ),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.PayloadSchemaType;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createPayloadIndexAsync(\n                \"{collection_name}\",\n                \"{field_name}\",\n                PayloadSchemaType.Keyword,\n                null,\n                true,\n                null,\n                null);\n"
               language: java
@@ -508,17 +514,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createFieldIndex() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tFieldName:      \"name_of_the_field_to_index\",\n\t\tFieldType:      qdrant.FieldType_FieldTypeKeyword.Enum(),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.createPayloadIndex(\"{collection_name}\", {\n  field_name: \"{field_name}\",\n  field_schema: \"keyword\",\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_field_index(\n        CreateFieldIndexCollectionBuilder::new(\n            \"{collection_name}\",\n            \"{field_name}\",\n            FieldType::Keyword,\n        ),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreatePayloadIndexAsync(\n  collectionName: \"{collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/index' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"field_name\": \"field_name\",\n  \"field_schema\": \"keyword\"\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.createPayloadIndex(\"{collection_name}\", {\n  field_name: \"{field_name}\",\n  field_schema: \"keyword\",\n});\n"
+              language: typescript
       description: Creates a payload index for a field in the specified collection.
       summary: Create payload index
       tags:
@@ -526,6 +526,9 @@ paths:
   /collections/{collection_name}/index/{field_name}:
     delete:
       x-fern-examples:
+        - code-samples:
+            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DeletePayloadIndexAsync(\n  collectionName: \"{collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
+              language: csharp
         - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
@@ -538,11 +541,17 @@ paths:
 '
               language: python
         - code-samples:
+            - code: "use qdrant_client::qdrant::DeleteFieldIndexCollectionBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_field_index(DeleteFieldIndexCollectionBuilder::new(\n        \"{collection_name}\",\n        \"{field_name}\",\n    ))\n    .await?;\n"
+              language: rust
+        - code-samples:
             - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deletePayloadIndexAsync(\"{collection_name}\", \"{field_name}\", true, null, null).get();\n"
               language: java
         - code-samples:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteFieldIndex() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.DeleteFieldIndex(context.Background(), &qdrant.DeleteFieldIndexCollection{\n\t\tCollectionName: \"{collection_name}\",\n\t\tFieldName:      \"{field_name}\",\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
+        - code-samples:
+            - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name/index/field_name' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
         - code-samples:
             - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
 
@@ -554,15 +563,6 @@ paths:
 
 '
               language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::DeleteFieldIndexCollectionBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_field_index(DeleteFieldIndexCollectionBuilder::new(\n        \"{collection_name}\",\n        \"{field_name}\",\n    ))\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DeletePayloadIndexAsync(\n  collectionName: \"{collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
-              language: csharp
-        - code-samples:
-            - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name/index/field_name' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
       description: Deletes a payload index for a field in the specified collection.
       summary: Delete payload index
       tags:
@@ -571,8 +571,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RetrieveAsync(\n  collectionName: \"{collection_name}\",\n  ids: [0, 30, 100],\n  withPayload: false,\n  withVectors: false\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.retrieve(\n    collection_name=\"{collection_name}\",\n    ids=[0, 3, 100],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::GetPointsBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .get_points(GetPointsBuilder::new(\n        \"{collection_name}\",\n        vec![0.into(), 30.into(), 100.into()],\n    ))\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .retrieveAsync(\"{collection_name}\", List.of(id(0), id(30), id(100)), false, false, null)\n    .get();\n"
               language: java
@@ -580,17 +586,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc getPoints() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tpoints, err := client.Get(context.Background(), &qdrant.GetPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tIds: []*qdrant.PointId{\n\t\t\tqdrant.NewIDNum(0), qdrant.NewID(\"3\"), qdrant.NewIDNum(100),\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Points: \", points)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.retrieve(\"{collection_name}\", {\n  ids: [0, 3, 100],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::GetPointsBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .get_points(GetPointsBuilder::new(\n        \"{collection_name}\",\n        vec![0.into(), 30.into(), 100.into()],\n    ))\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RetrieveAsync(\n  collectionName: \"{collection_name}\",\n  ids: [0, 30, 100],\n  withPayload: false,\n  withVectors: false\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"ids\": [\n    0,\n    3,\n    100\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.retrieve(\"{collection_name}\", {\n  ids: [0, 3, 100],\n});\n"
+              language: typescript
       description: Retrieves all details from multiple points.
       summary: Retrieve points
       tags:
@@ -598,8 +598,14 @@ paths:
     put:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpsertAsync(\n  collectionName: \"{collection_name}\",\n  points: new List<PointStruct>\n  {\n    new()\n    {\n      Id = 1,\n      Vectors = new[] { 0.9f, 0.1f, 0.1f },\n      Payload = { [\"city\"] = \"red\" }\n    },\n    new()\n    {\n      Id = 2,\n      Vectors = new[] { 0.1f, 0.9f, 0.1f },\n      Payload = { [\"city\"] = \"green\" }\n    },\n    new()\n    {\n      Id = 3,\n      Vectors = new[] { 0.1f, 0.1f, 0.9f },\n      Payload = { [\"city\"] = \"blue\" }\n    }\n  }\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.upsert(\n    collection_name=\"{collection_name}\",\n    points=[\n        models.PointStruct(\n            id=1,\n            payload={\n                \"color\": \"red\",\n            },\n            vector=[0.9, 0.1, 0.1],\n        ),\n        models.PointStruct(\n            id=2,\n            payload={\n                \"color\": \"green\",\n            },\n            vector=[0.1, 0.9, 0.1],\n        ),\n        models.PointStruct(\n            id=3,\n            payload={\n                \"color\": \"blue\",\n            },\n            vector=[0.1, 0.1, 0.9],\n        ),\n    ],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .upsert_points(\n        UpsertPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointStruct::new(\n                    1,\n                    vec![0.9, 0.1, 0.1],\n                    Payload::try_from(json!(\n                        {\"color\": \"red\"}\n                    ))\n                    .unwrap(),\n                ),\n                PointStruct::new(\n                    2,\n                    vec![0.1, 0.9, 0.1],\n                    Payload::try_from(json!(\n                        {\"color\": \"green\"}\n                    ))\n                    .unwrap(),\n                ),\n                PointStruct::new(\n                    3,\n                    vec![0.1, 0.1, 0.9],\n                    Payload::try_from(json!(\n                        {\"color\": \"blue\"}\n                    ))\n                    .unwrap(),\n                ),\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\nimport static io.qdrant.client.VectorsFactory.namedVectors;\n\nimport java.util.List;\nimport java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.PointStruct;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .upsertAsync(\n        \"{collection_name}\",\n        List.of(\n            PointStruct.newBuilder()\n                .setId(id(1))\n                .setVectors(\n                    namedVectors(\n                        Map.of(\n                            \"image\",\n                            vector(List.of(0.9f, 0.1f, 0.1f, 0.2f)),\n                            \"text\",\n                            vector(List.of(0.4f, 0.7f, 0.1f, 0.8f, 0.1f, 0.1f, 0.9f, 0.2f)))))\n                .build(),\n            PointStruct.newBuilder()\n                .setId(id(2))\n                .setVectors(\n                    namedVectors(\n                        Map.of(\n                            \"image\",\n                            List.of(0.2f, 0.1f, 0.3f, 0.9f),\n                            \"text\",\n                            List.of(0.5f, 0.2f, 0.7f, 0.4f, 0.7f, 0.2f, 0.3f, 0.9f))))\n                .build()))\n    .get();\n"
               language: java
@@ -607,17 +613,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc upsert() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresponse, err := client.Upsert(context.Background(), &qdrant.UpsertPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: []*qdrant.PointStruct{\n\t\t\t{\n\t\t\t\tId:      qdrant.NewIDNum(1),\n\t\t\t\tVectors: qdrant.NewVectors(0.9, 0.1, 0.1),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\t\"color\": \"red\",\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tId:      qdrant.NewIDNum(2),\n\t\t\t\tVectors: qdrant.NewVectors(0.1, 0.9, 0.1),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\t\"color\": \"green\",\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tId:      qdrant.NewIDNum(3),\n\t\t\t\tVectors: qdrant.NewVectors(0.1, 0.1, 0.9),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\t\"color\": \"blue\",\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Upsert status: \", response.GetStatus())\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.upsert(\"{collection_name}\", {\n  points: [\n    {\n      id: 1,\n      payload: { color: \"red\" },\n      vector: [0.9, 0.1, 0.1],\n    },\n    {\n      id: 2,\n      payload: { color: \"green\" },\n      vector: [0.1, 0.9, 0.1],\n    },\n    {\n      id: 3,\n      payload: { color: \"blue\" },\n      vector: [0.1, 0.1, 0.9],\n    },\n  ],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .upsert_points(\n        UpsertPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointStruct::new(\n                    1,\n                    vec![0.9, 0.1, 0.1],\n                    Payload::try_from(json!(\n                        {\"color\": \"red\"}\n                    ))\n                    .unwrap(),\n                ),\n                PointStruct::new(\n                    2,\n                    vec![0.1, 0.9, 0.1],\n                    Payload::try_from(json!(\n                        {\"color\": \"green\"}\n                    ))\n                    .unwrap(),\n                ),\n                PointStruct::new(\n                    3,\n                    vec![0.1, 0.1, 0.9],\n                    Payload::try_from(json!(\n                        {\"color\": \"blue\"}\n                    ))\n                    .unwrap(),\n                ),\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpsertAsync(\n  collectionName: \"{collection_name}\",\n  points: new List<PointStruct>\n  {\n    new()\n    {\n      Id = 1,\n      Vectors = new[] { 0.9f, 0.1f, 0.1f },\n      Payload = { [\"city\"] = \"red\" }\n    },\n    new()\n    {\n      Id = 2,\n      Vectors = new[] { 0.1f, 0.9f, 0.1f },\n      Payload = { [\"city\"] = \"green\" }\n    },\n    new()\n    {\n      Id = 3,\n      Vectors = new[] { 0.1f, 0.1f, 0.9f },\n      Payload = { [\"city\"] = \"blue\" }\n    }\n  }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"points\": [\n    {\n      \"id\": \"76874cce-1fb9-4e16-9b0b-f085ac06ed6f\",\n      \"payload\": {\n        \"color\": \"red\"\n      },\n      \"vector\": [\n        0.9,\n        0.1,\n        0.1\n      ]\n    },\n    {\n      \"id\": 1,\n      \"payload\": {\n        \"color\": \"green\"\n      },\n      \"vector\": [\n        0.1,\n        0.9,\n        0.1\n      ]\n    },\n    {\n      \"id\": 2,\n      \"payload\": {\n        \"color\": \"blue\"\n      },\n      \"vector\": [\n        0.1,\n        0.1,\n        0.9\n      ]\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.upsert(\"{collection_name}\", {\n  points: [\n    {\n      id: 1,\n      payload: { color: \"red\" },\n      vector: [0.9, 0.1, 0.1],\n    },\n    {\n      id: 2,\n      payload: { color: \"green\" },\n      vector: [0.1, 0.9, 0.1],\n    },\n    {\n      id: 3,\n      payload: { color: \"blue\" },\n      vector: [0.1, 0.1, 0.9],\n    },\n  ],\n});\n"
+              language: typescript
       description: Performs the insert + update action on specified points. Any point with an existing {id} will be overwritten.
       summary: Upsert points
       tags:
@@ -626,8 +626,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateBatchAsync(\n    \"{collection_name}\",\n    [\n        new()\n        {\n            Upsert = new()\n            {\n                Points =\n                {\n                    new PointStruct { Id = 1, Vectors = new[] { 0.9f, 0.1f, 0.1f } },\n                }\n            }\n        },\n        new()\n        {\n            UpdateVectors = new()\n            {\n                Points =\n                {\n                    new PointVectors { Id = 1, Vectors = new[] { 0.9f, 0.1f, 0.1f } },\n                }\n            }\n        },\n        new()\n        {\n            SetPayload = new()\n            {\n                PointsSelector = new PointsSelector { Points = new PointsIdsList { Ids = { 1 } } },\n                Payload = { [\"test_payload_2\"] = 2, [\"test_payload_3\"] = 3 }\n            }\n        }\n    ]\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.batch_update_points(\n    collection_name=\"{collection_name}\",\n    update_operations=[\n        models.UpsertOperation(\n            upsert=models.PointsList(\n                points=[\n                    models.PointStruct(\n                        id=1,\n                        vector=[1.0, 2.0, 3.0, 4.0],\n                        payload={},\n                    ),\n                ]\n            )\n        ),\n        models.UpdateVectorsOperation(\n            update_vectors=models.UpdateVectors(\n                points=[\n                    models.PointVectors(\n                        id=1,\n                        vector=[1.0, 2.0, 3.0, 4.0],\n                    )\n                ]\n            )\n        ),\n        models.SetPayloadOperation(\n            set_payload=models.SetPayload(\n                payload={\n                    \"test_payload_2\": 2,\n                    \"test_payload_3\": 3,\n                },\n                points=[1],\n            )\n        ),\n    ],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf,\n    points_update_operation::{\n        Operation, OverwritePayload, PointStructList, UpdateVectors,\n    },\n    PointStruct, PointVectors, PointsIdsList, PointsSelector, PointsUpdateOperation,\n    UpdateBatchPointsBuilder,\n};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\nuse std::collections::HashMap;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_points_batch(\n        UpdateBatchPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointsUpdateOperation {\n                    operation: Some(Operation::Upsert(PointStructList {\n                        points: vec![PointStruct::new(\n                            1,\n                            vec![1.0, 2.0, 3.0, 4.0],\n                            Payload::try_from(json!({})).unwrap(),\n                        )],\n                        ..Default::default()\n                    })),\n                },\n                PointsUpdateOperation {\n                    operation: Some(Operation::UpdateVectors(UpdateVectors {\n                        points: vec![PointVectors {\n                            id: Some(1.into()),\n                            vectors: Some(vec![1.0, 2.0, 3.0, 4.0].into()),\n                        }],\n                        ..Default::default()\n                    })),\n                },\n                PointsUpdateOperation {\n                    operation: Some(Operation::OverwritePayload(OverwritePayload {\n                        points_selector: Some(PointsSelector {\n                            points_selector_one_of: Some(PointsSelectorOneOf::Points(\n                                PointsIdsList {\n                                    ids: vec![1.into()],\n                                },\n                            )),\n                        }),\n                        payload: HashMap::from([(\"test_payload\".to_string(), 1.into())]),\n                        ..Default::default()\n                    })),\n                },\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\nimport java.util.Map;\n\nimport static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.ValueFactory.value;\nimport static io.qdrant.client.VectorsFactory.vectors;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.PointStruct;\nimport io.qdrant.client.grpc.Points.PointVectors;\nimport io.qdrant.client.grpc.Points.PointsIdsList;\nimport io.qdrant.client.grpc.Points.PointsSelector;\nimport io.qdrant.client.grpc.Points.PointsUpdateOperation;\nimport io.qdrant.client.grpc.Points.PointsUpdateOperation.PointStructList;\nimport io.qdrant.client.grpc.Points.PointsUpdateOperation.SetPayload;\nimport io.qdrant.client.grpc.Points.PointsUpdateOperation.UpdateVectors;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .batchUpdateAsync(\n        \"{collection_name}\",\n        List.of(\n            PointsUpdateOperation.newBuilder()\n            .setUpsert(\n                PointStructList.newBuilder()\n                .addPoints(\n                    PointStruct.newBuilder()\n                    .setId(id(1))\n                    .setVectors(vectors(\n                        1.0 f,\n                        2.0 f,\n                        3.0 f,\n                        4.0 f))\n                    .build())\n                .build())\n            .build(),\n            PointsUpdateOperation.newBuilder()\n            .setUpdateVectors(\n                UpdateVectors.newBuilder()\n                .addPoints(\n                    PointVectors.newBuilder()\n                    .setId(id(1))\n                    .setVectors(vectors(\n                        1.0 f,\n                        2.0 f,\n                        3.0 f,\n                        4.0 f))\n                    .build())\n                .build())\n            .build(),\n            PointsUpdateOperation.newBuilder()\n            .setSetPayload(\n                SetPayload.newBuilder()\n                .setPointsSelector(\n                    PointsSelector.newBuilder()\n                    .setPoints(PointsIdsList\n                        .newBuilder()\n                        .addIds(id(1))\n                        .build())\n                    .build())\n                .putAllPayload(\n                    Map.of(\"test_payload_2\",\n                        value(2),\n                        \"test_payload_3\",\n                        value(3)))\n                .build())\n            .build()))\n    .get();\n"
               language: java
@@ -635,17 +641,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc batchUpdate() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.UpdateBatch(context.Background(), &qdrant.UpdateBatchPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tOperations: []*qdrant.PointsUpdateOperation{\n\t\t\tqdrant.NewPointsUpdateUpsert(&qdrant.PointsUpdateOperation_PointStructList{\n\t\t\t\tPoints: []*qdrant.PointStruct{{\n\t\t\t\t\tId:      qdrant.NewIDNum(1),\n\t\t\t\t\tVectors: qdrant.NewVectors(1.0, 2.0, 3.0, 4.0),\n\t\t\t\t}},\n\t\t\t}),\n\t\t\tqdrant.NewPointsUpdateUpdateVectors(&qdrant.PointsUpdateOperation_UpdateVectors{\n\t\t\t\tPoints: []*qdrant.PointVectors{\n\t\t\t\t\t{\n\t\t\t\t\t\tId:      qdrant.NewIDNum(1),\n\t\t\t\t\t\tVectors: qdrant.NewVectors(0.1, 0.2, 0.3, 0.4),\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t}),\n\t\t\tqdrant.NewPointsUpdateSetPayload(&qdrant.PointsUpdateOperation_SetPayload{\n\t\t\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(1)),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\t\"test_payload_2\": 2,\n\t\t\t\t\t\"test_payload_3\": 3,\n\t\t\t\t}),\n\t\t\t}),\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.batchUpdate(\"{collection_name}\", {\n    operations: [\n        {\n            upsert: {\n                points: [\n                    {\n                        id: 1,\n                        vector: [1.0, 2.0, 3.0, 4.0],\n                        payload: {},\n                    },\n                ],\n            },\n        },\n        {\n            update_vectors: {\n                points: [\n                    {\n                        id: 1,\n                        vector: [1.0, 2.0, 3.0, 4.0],\n                    },\n                ],\n            },\n        },\n        {\n            set_payload: {\n                payload: {\n                    test_payload_2: 2,\n                    test_payload_3: 3,\n                },\n                points: [1],\n            },\n        },\n    ],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf,\n    points_update_operation::{\n        Operation, OverwritePayload, PointStructList, UpdateVectors,\n    },\n    PointStruct, PointVectors, PointsIdsList, PointsSelector, PointsUpdateOperation,\n    UpdateBatchPointsBuilder,\n};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\nuse std::collections::HashMap;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_points_batch(\n        UpdateBatchPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointsUpdateOperation {\n                    operation: Some(Operation::Upsert(PointStructList {\n                        points: vec![PointStruct::new(\n                            1,\n                            vec![1.0, 2.0, 3.0, 4.0],\n                            Payload::try_from(json!({})).unwrap(),\n                        )],\n                        ..Default::default()\n                    })),\n                },\n                PointsUpdateOperation {\n                    operation: Some(Operation::UpdateVectors(UpdateVectors {\n                        points: vec![PointVectors {\n                            id: Some(1.into()),\n                            vectors: Some(vec![1.0, 2.0, 3.0, 4.0].into()),\n                        }],\n                        ..Default::default()\n                    })),\n                },\n                PointsUpdateOperation {\n                    operation: Some(Operation::OverwritePayload(OverwritePayload {\n                        points_selector: Some(PointsSelector {\n                            points_selector_one_of: Some(PointsSelectorOneOf::Points(\n                                PointsIdsList {\n                                    ids: vec![1.into()],\n                                },\n                            )),\n                        }),\n                        payload: HashMap::from([(\"test_payload\".to_string(), 1.into())]),\n                        ..Default::default()\n                    })),\n                },\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateBatchAsync(\n    \"{collection_name}\",\n    [\n        new()\n        {\n            Upsert = new()\n            {\n                Points =\n                {\n                    new PointStruct { Id = 1, Vectors = new[] { 0.9f, 0.1f, 0.1f } },\n                }\n            }\n        },\n        new()\n        {\n            UpdateVectors = new()\n            {\n                Points =\n                {\n                    new PointVectors { Id = 1, Vectors = new[] { 0.9f, 0.1f, 0.1f } },\n                }\n            }\n        },\n        new()\n        {\n            SetPayload = new()\n            {\n                PointsSelector = new PointsSelector { Points = new PointsIdsList { Ids = { 1 } } },\n                Payload = { [\"test_payload_2\"] = 2, [\"test_payload_3\"] = 3 }\n            }\n        }\n    ]\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/batch' \\\n  --header 'Content-Type: application/json' \\\n  --header 'api-key: <api-key-value>' \\\n  --data-raw '{\n  \"operations\": [\n    {\n      \"upsert\": {\n        \"points\": [\n          {\n            \"id\": 1,\n            \"vector\": [\n              0.4,\n              0.3,\n              0.2,\n              0.1\n            ]\n          }\n        ]\n      }\n    },\n    {\n      \"update_vectors\": {\n        \"points\": [\n          {\n            \"id\": 1,\n            \"vector\": [\n              0.11,\n              0.22,\n              0.33,\n              0.44\n            ]\n          }\n        ]\n      }\n    },\n    {\n      \"set_payload\": {\n        \"payload\": {\n          \"test_payload_2\": 2,\n          \"test_payload_3\": 3\n        },\n        \"points\": [\n          1\n        ]\n      }\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.batchUpdate(\"{collection_name}\", {\n    operations: [\n        {\n            upsert: {\n                points: [\n                    {\n                        id: 1,\n                        vector: [1.0, 2.0, 3.0, 4.0],\n                        payload: {},\n                    },\n                ],\n            },\n        },\n        {\n            update_vectors: {\n                points: [\n                    {\n                        id: 1,\n                        vector: [1.0, 2.0, 3.0, 4.0],\n                    },\n                ],\n            },\n        },\n        {\n            set_payload: {\n                payload: {\n                    test_payload_2: 2,\n                    test_payload_3: 3,\n                },\n                points: [1],\n            },\n        },\n    ],\n});\n"
+              language: typescript
       description: Batch updates points, including their respective vectors and payloads.
       summary: Batch update points
       tags:
@@ -654,8 +654,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CountAsync(\n  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\", \"red\"),\n  exact: true\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.count(\n    collection_name=\"{collection_name}\",\n    count_filter=models.Filter(\n        must=[\n            models.FieldCondition(key=\"color\", match=models.MatchValue(value=\"red\")),\n        ]\n    ),\n    exact=True,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, CountPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .count(\n        CountPointsBuilder::new(\"{collection_name}\")\n            .filter(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .exact(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\n\nQdrantClient client = new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .countAsync(\n        \"{collection_name}\",\n        Filter.newBuilder().addMust(matchKeyword(\"color\", \"red\")).build(),\n        true)\n    .get();\n"
               language: java
@@ -663,17 +669,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc count() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tcount, err := client.Count(context.Background(), &qdrant.CountPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Count:\", count)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.count(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    exact: true,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, CountPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .count(\n        CountPointsBuilder::new(\"{collection_name}\")\n            .filter(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .exact(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CountAsync(\n  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\", \"red\"),\n  exact: true\n);\n"
-              language: csharp
-        - code-samples:
             - code: "# Count total number of points in a collection\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/count' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"exact\": true\n}'\n\n# Count points satisfying a filter condition\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/count' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"exact\": true\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.count(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    exact: true,\n});\n"
+              language: typescript
       description: Counts the number of points that match a specified filtering condition.
       summary: Count points
       tags:
@@ -681,21 +681,6 @@ paths:
   /collections/{collection_name}/points/delete:
     post:
       x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete(\n    collection_name=\"{collection_name}\",\n    points_selector=models.PointIdsList(\n        points=[0, 3, 100],\n    ),\n)\n\nclient.delete(\n    collection_name=\"{collection_name}\",\n    points_selector=models.FilterSelector(\n        filter=models.Filter(\n            must=[\n                models.FieldCondition(\n                    key=\"color\",\n                    match=models.MatchValue(value=\"red\"),\n                ),\n            ],\n        )\n    ),\n)\n"
-              language: python
-        - code-samples:
-            - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteAsync(\"{collection_name}\", List.of(id(0), id(3), id(100)));\n\nclient\n    .deleteAsync(\n        \"{collection_name}\",\n        Filter.newBuilder().addMust(matchKeyword(\"color\", \"red\")).build())\n    .get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc delete() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(), &qdrant.DeletePoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: qdrant.NewPointsSelectorIDs([]*qdrant.PointId{\n\t\t\tqdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100),\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(), &qdrant.DeletePoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: qdrant.NewPointsSelectorFilter(&qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.delete(\"{collection_name}\", {\n  points: [0, 3, 100],\n});\n\nclient.delete(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, DeletePointsBuilder, Filter, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_points(\n        DeletePointsBuilder::new(\"{collection_name}\")\n            .points(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 100.into()],\n            })\n            .wait(true),\n    )\n    .await?;\n\nclient\n    .delete_points(\n        DeletePointsBuilder::new(\"{collection_name}\")\n            .points(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .wait(true),\n    )\n    .await?;\n"
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -711,8 +696,23 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete(\n    collection_name=\"{collection_name}\",\n    points_selector=models.PointIdsList(\n        points=[0, 3, 100],\n    ),\n)\n\nclient.delete(\n    collection_name=\"{collection_name}\",\n    points_selector=models.FilterSelector(\n        filter=models.Filter(\n            must=[\n                models.FieldCondition(\n                    key=\"color\",\n                    match=models.MatchValue(value=\"red\"),\n                ),\n            ],\n        )\n    ),\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, DeletePointsBuilder, Filter, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_points(\n        DeletePointsBuilder::new(\"{collection_name}\")\n            .points(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 100.into()],\n            })\n            .wait(true),\n    )\n    .await?;\n\nclient\n    .delete_points(\n        DeletePointsBuilder::new(\"{collection_name}\")\n            .points(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .wait(true),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteAsync(\"{collection_name}\", List.of(id(0), id(3), id(100)));\n\nclient\n    .deleteAsync(\n        \"{collection_name}\",\n        Filter.newBuilder().addMust(matchKeyword(\"color\", \"red\")).build())\n    .get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc delete() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(), &qdrant.DeletePoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: qdrant.NewPointsSelectorIDs([]*qdrant.PointId{\n\t\t\tqdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100),\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(), &qdrant.DeletePoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: qdrant.NewPointsSelectorFilter(&qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "# Delete points by IDs\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"points\": [\n    0,\n    3,\n    100\n  ]\n}'\n\n# Delete points by filter \ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  }\n}'\n"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.delete(\"{collection_name}\", {\n  points: [0, 3, 100],\n});\n\nclient.delete(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n});\n"
+              language: typescript
       description: Deletes specified points from the collection.
       summary: Delete points
       tags:
@@ -721,8 +721,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DiscoverAsync(\n  collectionName: \"{collection_name}\",\n  target: new TargetVector\n  {\n    Single = new VectorExample { Vector = new float[] { 0.2f, 0.1f, 0.9f, 0.7f }, }\n  },\n  context:\n  [\n    new()\n    {\n      Positive = new VectorExample { Id = 100 },\n      Negative = new VectorExample { Id = 718 }\n    },\n    new()\n    {\n      Positive = new VectorExample { Id = 200 },\n      Negative = new VectorExample { Id = 300 }\n    }\n  ],\n  limit: 10\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.discover(\n    \"{collection_name}\",\n    target=[0.2, 0.1, 0.9, 0.7],\n    context=[\n        models.ContextExamplePair(positive=100, negative=718),\n        models.ContextExamplePair(positive=200, negative=300),\n    ],\n    limit=10,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    target_vector::Target, vector_example::Example, ContextExamplePairBuilder,\n    DiscoverPointsBuilder, VectorExample,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .discover(\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(718.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(200.into()))\n                    .negative(Example::Id(300.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .target(Target::Single(VectorExample {\n            example: Some(Example::Vector(vec![0.2, 0.1, 0.9, 0.7].into())),\n        })),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.ContextExamplePair;\nimport io.qdrant.client.grpc.Points.DiscoverPoints;\nimport io.qdrant.client.grpc.Points.TargetVector;\nimport io.qdrant.client.grpc.Points.VectorExample;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .discoverAsync(\n        DiscoverPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setTarget(\n                TargetVector.newBuilder()\n                    .setSingle(\n                        VectorExample.newBuilder()\n                            .setVector(vector(0.2f, 0.1f, 0.9f, 0.7f))\n                            .build()))\n            .addAllContext(\n                List.of(\n                    ContextExamplePair.newBuilder()\n                        .setPositive(VectorExample.newBuilder().setId(id(100)))\n                        .setNegative(VectorExample.newBuilder().setId(id(718)))\n                        .build(),\n                    ContextExamplePair.newBuilder()\n                        .setPositive(VectorExample.newBuilder().setId(id(200)))\n                        .setNegative(VectorExample.newBuilder().setId(id(300)))\n                        .build()))\n            .setLimit(10)\n            .build())\n    .get();\n"
               language: java
@@ -730,17 +736,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc discover() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\t\t\tTarget: qdrant.NewVectorInput(0.2, 0.1, 0.9, 0.7),\n\t\t\tContext: &qdrant.ContextInput{\n\t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\t\t\t}, {\n\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\t\t\t\t}},\n\t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.discover(\"{collection_name}\", {\n    target: [0.2, 0.1, 0.9, 0.7],\n    context: [\n        {\n            positive: 100,\n            negative: 718,\n        },\n        {\n            positive: 200,\n            negative: 300,\n        },\n    ],\n    limit: 10,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    target_vector::Target, vector_example::Example, ContextExamplePairBuilder,\n    DiscoverPointsBuilder, VectorExample,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .discover(\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(718.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(200.into()))\n                    .negative(Example::Id(300.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .target(Target::Single(VectorExample {\n            example: Some(Example::Vector(vec![0.2, 0.1, 0.9, 0.7].into())),\n        })),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DiscoverAsync(\n  collectionName: \"{collection_name}\",\n  target: new TargetVector\n  {\n    Single = new VectorExample { Vector = new float[] { 0.2f, 0.1f, 0.9f, 0.7f }, }\n  },\n  context:\n  [\n    new()\n    {\n      Positive = new VectorExample { Id = 100 },\n      Negative = new VectorExample { Id = 718 }\n    },\n    new()\n    {\n      Positive = new VectorExample { Id = 200 },\n      Negative = new VectorExample { Id = 300 }\n    }\n  ],\n  limit: 10\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/discover' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"target\": [\n    0.2,\n    0.1,\n    0.9,\n    0.7\n  ],\n  \"context\": [\n    {\n      \"positive\": \"7f6652c4-89bd-40e0-ab1d-510f7fcddd2b\",\n      \"negative\": \"2c2c9f86-0171-4bd2-9ab0-b4754682cddd\"\n    }\n  ],\n  \"limit\": 10\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.discover(\"{collection_name}\", {\n    target: [0.2, 0.1, 0.9, 0.7],\n    context: [\n        {\n            positive: 100,\n            negative: 718,\n        },\n        {\n            positive: 200,\n            negative: 300,\n        },\n    ],\n    limit: 10,\n});\n"
+              language: typescript
       description: >
         Retrieves the most similar points to a given target, constrained by the provided context.
 
@@ -755,8 +755,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar discoverPoints = new List<DiscoverPoints>\n{\n    new DiscoverPoints\n    {\n        CollectionName = \"{collection_name}\",\n        Target = new TargetVector\n        {\n            Single = new VectorExample { Vector = new float[] { 0.2f, 0.1f, 0.9f, 0.7f }, }\n        },\n        Context =\n        {\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 100 },\n                Negative = new VectorExample { Id = 718 }\n            },\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 200 },\n                Negative = new VectorExample { Id = 300 }\n            }\n        },\n        Limit = 10\n    },\n    new DiscoverPoints\n    {\n        CollectionName = \"{collection_name}\",\n        Target = new TargetVector\n        {\n            Single = new VectorExample { Vector = new float[] { 0.5f, 0.3f, 0.2f, 0.3f }, }\n        },\n        Context =\n        {\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 342 },\n                Negative = new VectorExample { Id = 213 }\n            },\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 100 },\n                Negative = new VectorExample { Id = 200 }\n            }\n        },\n        Limit = 10\n    }\n};\nawait client.DiscoverBatchAsync(\"{collection_name}\", discoverPoints);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\ndiscover_queries = [\n    models.DiscoverRequest(\n        target=[0.2, 0.1, 0.9, 0.7],\n        context=[\n            models.ContextExamplePair(\n                positive=100,\n                negative=718,\n            ),\n            models.ContextExamplePair(\n                positive=200,\n                negative=300,\n            ),\n        ],\n        limit=10,\n    ),\n    models.DiscoverRequest(\n        target=[0.5, 0.3, 0.2, 0.3],\n        context=[\n            models.ContextExamplePair(\n                positive=342,\n                negative=213,\n            ),\n            models.ContextExamplePair(\n                positive=100,\n                negative=200,\n            ),\n        ],\n        limit=5,\n    ),\n]\n\nclient.discover_batch(\"{collection_name}\", discover_queries)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    vector_example::Example, ContextExamplePairBuilder, DiscoverBatchPointsBuilder,\n    DiscoverPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet discover_points = DiscoverBatchPointsBuilder::new(\n    \"{collection_name}\",\n    vec![\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(718.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(200.into()))\n                    .negative(Example::Id(300.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .build(),\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(342.into()))\n                    .negative(Example::Id(213.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(200.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .build(),\n    ],\n);\n\nclient.discover_batch(&discover_points.build()).await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\n\nimport java.util.Arrays;\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.ContextExamplePair;\nimport io.qdrant.client.grpc.Points.DiscoverPoints;\nimport io.qdrant.client.grpc.Points.TargetVector;\nimport io.qdrant.client.grpc.Points.VectorExample;\n\nQdrantClient client = new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nList <DiscoverPoints> discoverPoints = Arrays.asList(\n    DiscoverPoints.newBuilder()\n    .setCollectionName(\"{collection_name}\")\n    .setTarget(\n        TargetVector.newBuilder()\n        .setSingle(\n            VectorExample.newBuilder()\n            .setVector(vector(\n                0.2 f,\n                0.1 f,\n                0.9 f,\n                0.7 f))\n            .build()))\n    .addAllContext(\n        List.of(\n            ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n                .newBuilder()\n                .setId(id(100)))\n            .setNegative(VectorExample\n                .newBuilder()\n                .setId(id(718)))\n            .build(),\n            ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n                .newBuilder()\n                .setId(id(200)))\n            .setNegative(VectorExample\n                .newBuilder()\n                .setId(id(300)))\n            .build()))\n    .setLimit(10)\n    .build(),\n    DiscoverPoints.newBuilder()\n    .setCollectionName(\"{collection_name}\")\n    .setTarget(\n        TargetVector.newBuilder()\n        .setSingle(\n            VectorExample.newBuilder()\n            .setVector(vector(\n                0.5 f, 0.3 f, 0.2 f, 0.3 f))\n            .build()))\n    .addAllContext(\n        List.of(\n            ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n                .newBuilder()\n                .setId(id(342)))\n            .setNegative(VectorExample\n                .newBuilder()\n                .setId(id(213)))\n            .build(),\n            ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n                .newBuilder()\n                .setId(id(100)))\n            .setNegative(VectorExample\n                .newBuilder()\n                .setId(id(200)))\n            .build()))\n    .setLimit(10)\n    .build());\nclient.discoverBatchAsync(\"{collection_name}\", discoverPoints, null);\n"
               language: java
@@ -764,17 +770,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc discoverBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(), &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\t\t\t\t\tTarget: qdrant.NewVectorInput(0.2, 0.1, 0.9, 0.7),\n\t\t\t\t\tContext: &qdrant.ContextInput{\n\t\t\t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\t\t\t\t\t}, {\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\t\t\t\t\t\t}},\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\t\t\t\t\tTarget: qdrant.NewVectorInput(0.5, 0.3, 0.2, 0.3),\n\t\t\t\t\tContext: &qdrant.ContextInput{\n\t\t\t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(342)),\n\t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(213)),\n\t\t\t\t\t\t}, {\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\t\t\t\t\t\t}},\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst searches = [\n    {\n        target: [0.2, 0.1, 0.9, 0.7],\n        context: [\n            {\n                positive: 100,\n                negative: 718,\n            },\n            {\n                positive: 200,\n                negative: 300,\n            },\n        ],\n        limit: 10,\n    },\n    {\n        target: [0.5, 0.3, 0.2, 0.3],\n        context: [\n            {\n                positive: 342,\n                negative: 213,\n            },\n            {\n                positive: 100,\n                negative: 200,\n            },\n        ],\n        limit: 5,\n    },\n];\n\nclient.discoverBatchPoints(\"{collection_name}\", {\n    searches,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    vector_example::Example, ContextExamplePairBuilder, DiscoverBatchPointsBuilder,\n    DiscoverPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet discover_points = DiscoverBatchPointsBuilder::new(\n    \"{collection_name}\",\n    vec![\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(718.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(200.into()))\n                    .negative(Example::Id(300.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .build(),\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(342.into()))\n                    .negative(Example::Id(213.into()))\n                    .build(),\n                ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n                    .negative(Example::Id(200.into()))\n                    .build(),\n            ],\n            10,\n        )\n        .build(),\n    ],\n);\n\nclient.discover_batch(&discover_points.build()).await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar discoverPoints = new List<DiscoverPoints>\n{\n    new DiscoverPoints\n    {\n        CollectionName = \"{collection_name}\",\n        Target = new TargetVector\n        {\n            Single = new VectorExample { Vector = new float[] { 0.2f, 0.1f, 0.9f, 0.7f }, }\n        },\n        Context =\n        {\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 100 },\n                Negative = new VectorExample { Id = 718 }\n            },\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 200 },\n                Negative = new VectorExample { Id = 300 }\n            }\n        },\n        Limit = 10\n    },\n    new DiscoverPoints\n    {\n        CollectionName = \"{collection_name}\",\n        Target = new TargetVector\n        {\n            Single = new VectorExample { Vector = new float[] { 0.5f, 0.3f, 0.2f, 0.3f }, }\n        },\n        Context =\n        {\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 342 },\n                Negative = new VectorExample { Id = 213 }\n            },\n            new ContextExamplePair()\n            {\n                Positive = new VectorExample { Id = 100 },\n                Negative = new VectorExample { Id = 200 }\n            }\n        },\n        Limit = 10\n    }\n};\nawait client.DiscoverBatchAsync(\"{collection_name}\", discoverPoints);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/discover/batch' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n      \"target\": [\n        0.2,\n        0.1,\n        0.9,\n        0.7\n      ],\n      \"context\": [\n        {\n          \"positive\": \"7f6652c4-89bd-40e0-ab1d-510f7fcddd2b\",\n          \"negative\": \"2c2c9f86-0171-4bd2-9ab0-b4754682cddd\"\n        }\n      ],\n      \"limit\": 1\n    },\n    {\n      \"target\": [\n        0.5,\n        0.3,\n        0.2,\n        0.3\n      ],\n      \"context\": [\n        {\n          \"positive\": 342,\n          \"negative\": 213\n        }\n      ],\n      \"limit\": 1\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst searches = [\n    {\n        target: [0.2, 0.1, 0.9, 0.7],\n        context: [\n            {\n                positive: 100,\n                negative: 718,\n            },\n            {\n                positive: 200,\n                negative: 300,\n            },\n        ],\n        limit: 10,\n    },\n    {\n        target: [0.5, 0.3, 0.2, 0.3],\n        context: [\n            {\n                positive: 342,\n                negative: 213,\n            },\n            {\n                positive: 100,\n                negative: 200,\n            },\n        ],\n        limit: 5,\n    },\n];\n\nclient.discoverBatchPoints(\"{collection_name}\", {\n    searches,\n});\n"
+              language: typescript
       description: Retrieves points in batches based on the target and/or positive and negative example pairs.
       summary: Discover batch points
       tags:
@@ -783,8 +783,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SetPayloadAsync(\n  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string, Value> { { \"property1\", \"string\" }, { \"property2\", \"string\" } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.set_payload(\n    collection_name=\"{collection_name}\",\n    payload={\n        \"property1\": \"string\",\n        \"property2\": \"string\",\n    },\n    points=[0, 3, 10],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet payload: Payload = json!({\n    \"property1\": \"string\",\n    \"property2\": \"string\",\n})\n.try_into()\n.unwrap();\n\nclient\n    .set_payload(\n        SetPayloadPointsBuilder::new(\"{collection_name}\", payload)\n            .points_selector(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            })\n            .wait(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.ValueFactory.value;\n\nimport java.util.List;\nimport java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .setPayloadAsync(\n        \"{collection_name}\",\n        Map.of(\"property1\", value(\"string\"), \"property2\", value(\"string\")),\n        List.of(id(0), id(3), id(10)),\n        true,\n        null,\n        null)\n    .get();\n"
               language: java
@@ -792,17 +798,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc setPayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.SetPayload(context.Background(), &qdrant.SetPayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\"property1\": \"string\",\n\t\t\t\"property2\": \"string\",\n\t\t}),\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(10)),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.setPayload(\"{collection_name}\", {\n  payload: {\n    property1: \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet payload: Payload = json!({\n    \"property1\": \"string\",\n    \"property2\": \"string\",\n})\n.try_into()\n.unwrap();\n\nclient\n    .set_payload(\n        SetPayloadPointsBuilder::new(\"{collection_name}\", payload)\n            .points_selector(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            })\n            .wait(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SetPayloadAsync(\n  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string, Value> { { \"property1\", \"string\" }, { \"property2\", \"string\" } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "# Set payload by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\": \"some_value\",\n    \"property2\": 32,\n    \"property3\": true\n  },\n  \"points\": [\n    0,\n    3,\n    10\n  ]\n}'\n\n# Set payload by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"payload\": {\n    \"property1\": \"some_value\",\n    \"property2\": 32,\n    \"property3\": true\n  }\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.setPayload(\"{collection_name}\", {\n  payload: {\n    property1: \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n});\n"
+              language: typescript
       description: Sets payload values for specified points.
       summary: Set payload
       tags:
@@ -810,8 +810,14 @@ paths:
     put:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.OverwritePayloadAsync(\n  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string, Value> { { \"property1\", \"string\" }, { \"property2\", \"string\" } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.overwrite_payload(\n    collection_name=\"{collection_name}\",\n    payload={\n        \"property1\": \"string\",\n        \"property2\": \"string\",\n    },\n    points=[0, 3, 10],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf, PointsIdsList, SetPayloadPointsBuilder,\n};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet payload: Payload = json!({\n    \"property1\": \"string\",\n    \"property2\": \"string\",\n})\n.try_into()\n.unwrap();\n\nclient\n    .overwrite_payload(\n        SetPayloadPointsBuilder::new(\"{collection_name}\", payload)\n            .points_selector(PointsSelectorOneOf::Points(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            }))\n            .wait(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.ValueFactory.value;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .overwritePayloadAsync(\n        \"{collection_name}\",\n        Map.of(\"property1\", value(\"string\"), \"property2\", value(\"string\")),\n        List.of(id(0), id(3), id(10)),\n        true,\n        null,\n        null)\n    .get();\n"
               language: java
@@ -819,17 +825,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc overwritePayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.OverwritePayload(context.Background(), &qdrant.SetPayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\"property1\": \"string\",\n\t\t\t\"property2\": \"string\",\n\t\t}),\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(10)),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.overwritePayload(\"{collection_name}\", {\n  payload: {\n    property1: \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf, PointsIdsList, SetPayloadPointsBuilder,\n};\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet payload: Payload = json!({\n    \"property1\": \"string\",\n    \"property2\": \"string\",\n})\n.try_into()\n.unwrap();\n\nclient\n    .overwrite_payload(\n        SetPayloadPointsBuilder::new(\"{collection_name}\", payload)\n            .points_selector(PointsSelectorOneOf::Points(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            }))\n            .wait(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.OverwritePayloadAsync(\n  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string, Value> { { \"property1\", \"string\" }, { \"property2\", \"string\" } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "# Overwrite payload by ID\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/payload' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\": \"string\",\n    \"property2\": \"string\"\n  },\n  \"points\": [\n    0,\n    3,\n    10\n  ]\n}'\n\n# Overwrite payload by filter\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/payload' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\": \"string\",\n    \"property2\": \"string\"\n  },\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  }\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.overwritePayload(\"{collection_name}\", {\n  payload: {\n    property1: \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n});\n"
+              language: typescript
       description: Replaces the entire payload of a specified point with a new payload.
       summary: Overwrite payload
       tags:
@@ -837,21 +837,6 @@ paths:
   /collections/{collection_name}/points/payload/clear:
     post:
       x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.clear_payload(\n    collection_name=\"{collection_name}\",\n    points_selector=[0, 3, 100],\n)\n"
-              language: python
-        - code-samples:
-            - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.clearPayloadAsync(\"{collection_name}\", List.of(id(0), id(3), id(100)), null, null, null)\n                .get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc clearPayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.ClearPayload(context.Background(), &qdrant.ClearPayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints:         qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewID(\"3\"), qdrant.NewIDNum(100)),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.clearPayload(\"{collection_name}\", {\n  points: [0, 3, 100],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{ClearPayloadPointsBuilder, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .clear_payload(ClearPayloadPointsBuilder::new(\"{collection_name}\").points(\n        PointsIdsList {\n            ids: vec![0.into(), 3.into(), 100.into()],\n        },\n    ))\n    .await?;\n"
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -864,8 +849,23 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.clear_payload(\n    collection_name=\"{collection_name}\",\n    points_selector=[0, 3, 100],\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{ClearPayloadPointsBuilder, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .clear_payload(ClearPayloadPointsBuilder::new(\"{collection_name}\").points(\n        PointsIdsList {\n            ids: vec![0.into(), 3.into(), 100.into()],\n        },\n    ))\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.clearPayloadAsync(\"{collection_name}\", List.of(id(0), id(3), id(100)), null, null, null)\n                .get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc clearPayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.ClearPayload(context.Background(), &qdrant.ClearPayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints:         qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewID(\"3\"), qdrant.NewIDNum(100)),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/clear' \\\n  --header 'Content-Type: application/json' \\\n  --header 'api-key: <api-key-value>' \\\n  --data-raw '{\n  \"points\": [\n    0,\n    3,\n    100\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.clearPayload(\"{collection_name}\", {\n  points: [0, 3, 100],\n});\n"
+              language: typescript
       description: Removes the entire payload for specified points.
       summary: Clear payload
       tags:
@@ -873,21 +873,6 @@ paths:
   /collections/{collection_name}/points/payload/delete:
     post:
       x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_payload(\n    collection_name=\"{collection_name}\",\n    keys=[\"color\", \"price\"],\n    points=[0, 3, 100],\n)\n"
-              language: python
-        - code-samples:
-            - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .deletePayloadAsync(\n        \"{collection_name}\",\n        List.of(\"color\", \"price\"),\n        List.of(id(0), id(3), id(100)),\n        true,\n        null,\n        null)\n    .get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deletePayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.DeletePayload(context.Background(), &qdrant.DeletePayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100)),\n\t\tKeys:           []string{\"color\", \"price\"},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.deletePayload(\"{collection_name}\", {\n  keys: [\"color\", \"price\"],\n  points: [0, 3, 100],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{DeletePayloadPointsBuilder, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_payload(\n        DeletePayloadPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\"color\".to_string(), \"price\".to_string()],\n        )\n        .points_selector(PointsIdsList {\n            ids: vec![0.into(), 3.into(), 100.into()],\n        })\n        .wait(true),\n    )\n    .await?;\n"
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -900,8 +885,23 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_payload(\n    collection_name=\"{collection_name}\",\n    keys=[\"color\", \"price\"],\n    points=[0, 3, 100],\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{DeletePayloadPointsBuilder, PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_payload(\n        DeletePayloadPointsBuilder::new(\n            \"{collection_name}\",\n            vec![\"color\".to_string(), \"price\".to_string()],\n        )\n        .points_selector(PointsIdsList {\n            ids: vec![0.into(), 3.into(), 100.into()],\n        })\n        .wait(true),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .deletePayloadAsync(\n        \"{collection_name}\",\n        List.of(\"color\", \"price\"),\n        List.of(id(0), id(3), id(100)),\n        true,\n        null,\n        null)\n    .get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deletePayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.DeletePayload(context.Background(), &qdrant.DeletePayloadPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100)),\n\t\tKeys:           []string{\"color\", \"price\"},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "# Delete payload by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"keys\": [\n    \"color\",\n    \"price\"\n  ],\n  \"points\": [\n    0,\n    3,\n    100\n  ]\n}'\n\n# Delete payload by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"keys\": [\n    \"color\",\n    \"price\"\n  ],\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  }\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.deletePayload(\"{collection_name}\", {\n  keys: [\"color\", \"price\"],\n  points: [0, 3, 100],\n});\n"
+              language: typescript
       description: Deletes a specified key payload for points.
       summary: Delete payload
       tags:
@@ -910,8 +910,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\n// Query nearest by ID\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tquery: Guid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")\n);\n\n// Recommend on the average of these vectors\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tquery: new RecommendInput\n\t{\n\t\tPositive =\n\t\t{\n\t\t\tGuid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"),\n\t\t\tnew float[] { 0.11f, 0.35f, 0.6f }\n\t\t},\n\t\tNegative = { new float[] { 0.01f, 0.45f, 0.67f } }\n\t}\n);\n\n// Fusion query\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch: new List<PrefetchQuery>\n\t{\n\t\tnew()\n\t\t{\n\t\t\tQuery = new (float, uint)[] { (0.22f, 1), (0.8f, 42), },\n\t\t\tUsing = \"sparse\",\n\t\t\tLimit = 20\n\t\t},\n\t\tnew()\n\t\t{\n\t\t\tQuery = new float[] { 0.01f, 0.45f, 0.67f },\n\t\t\tUsing = \"dense\",\n\t\t\tLimit = 20\n\t\t}\n\t},\n\tquery: Fusion.Rrf\n);\n\n// 2-stage query\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch: new List<PrefetchQuery>\n\t{\n\t\tnew() { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 }\n\t},\n\tquery: new float[][] { [0.1f, 0.2f], [0.2f, 0.1f], [0.8f, 0.9f] },\n\tusingVector: \"colbert\",\n\tlimit: 10\n);\n\n// Random sampling (as of 1.11.0)\nawait client.QueryAsync(\n    collectionName: \"{collection_name}\",\n    query: Sample.Random\n);\n\n// Score boost depending on payload conditions (as of 1.14.0)\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\tExpression = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"$score\",\n\t\t\t\tnew MultExpression\n\t\t\t\t{\n\t\t\t\t\tMult = { 0.5f, Match(\"tag\", [\"h1\", \"h2\", \"h3\", \"h4\"]) },\n\t\t\t\t},\n\t\t\t\tnew MultExpression { Mult = { 0.25f, Match(\"tag\", [\"p\", \"li\"]) } },\n\t\t\t},\n\t\t},\n\t},\n\tlimit: 10\n);\n\n// Score boost geographically closer points (as of 1.14.0)\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\tExpression = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"$score\",\n\t\t\t\tWithExpDecay(\n\t\t\t\t\tnew()\n\t\t\t\t\t{\n\t\t\t\t\t\tX = new GeoDistance\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\tOrigin = new GeoPoint { Lat = 52.504043, Lon = 13.393236 },\n\t\t\t\t\t\t\tTo = \"geo.location\",\n\t\t\t\t\t\t},\n\t\t\t\t\t\tScale = 5000,\n\t\t\t\t\t}\n\t\t\t\t),\n\t\t\t},\n\t\t},\n\t\tDefaults =\n\t\t{\n\t\t\t[\"geo.location\"] = new Dictionary<string, Value>\n\t\t\t{\n\t\t\t\t[\"lat\"] = 48.137154,\n\t\t\t\t[\"lon\"] = 11.576124,\n\t\t\t},\n\t\t},\n\t}\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\n# Query nearest by ID\nnearest = client.query_points(\n    collection_name=\"{collection_name}\",\n    query=\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\",\n)\n\n# Recommend on the average of these vectors\nrecommended = client.query_points(\n    collection_name=\"{collection_name}\",\n    query=models.RecommendQuery(recommend=models.RecommendInput(\n        positive=[\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\", [0.11, 0.35, 0.6, ...]],\n        negative=[[0.01, 0.45, 0.67, ...]]\n    ))\n)\n\n# Fusion query\nhybrid = client.query_points(\n    collection_name=\"{collection_name}\",\n    prefetch=[\n        models.Prefetch(\n            query=models.SparseVector(indices=[1, 42], values=[0.22, 0.8]),\n            using=\"sparse\",\n            limit=20,\n        ),\n        models.Prefetch(\n            query=[0.01, 0.45, 0.67, ...],  # <-- dense vector\n            using=\"dense\",\n            limit=20,\n        ),\n    ],\n    query=models.FusionQuery(fusion=models.Fusion.RRF),\n)\n\n# 2-stage query\nrefined = client.query_points(\n    collection_name=\"{collection_name}\",\n    prefetch=models.Prefetch(\n        query=[0.01, 0.45, 0.67, ...],  # <-- dense vector\n        limit=100,\n    ),\n    query=[\n        [0.1, 0.2, ...],  # <─┐\n        [0.2, 0.1, ...],  # < ├─ multi-vector\n        [0.8, 0.9, ...],  # < ┘\n    ],\n    using=\"colbert\",\n    limit=10,\n)\n\n# Random sampling (as of 1.11.0)\nsampled = client.query_points(\n    collection_name=\"{collection_name}\",\n    query=models.SampleQuery(sample=models.Sample.RANDOM)\n)\n\n# Score boost depending on payload conditions (as of 1.14.0)\ntag_boosted = client.query_points(\n    collection_name=\"{collection_name}\",\n    prefetch=models.Prefetch(\n        query=[0.2, 0.8, ...],  # <-- dense vector\n        limit=50\n    ),\n    query=models.FormulaQuery(\n        formula=models.SumExpression(sum=[\n            \"$score\",\n            models.MultExpression(mult=[0.5, models.FieldCondition(key=\"tag\", match=models.MatchAny(any=[\"h1\", \"h2\", \"h3\", \"h4\"]))]),\n            models.MultExpression(mult=[0.25, models.FieldCondition(key=\"tag\", match=models.MatchAny(any=[\"p\", \"li\"]))])\n        ]\n    ))\n)\n\n# Score boost geographically closer points (as of 1.14.0)\ngeo_boosted = client.query_points(\n    collection_name=\"{collection_name}\",\n    prefetch=models.Prefetch(\n        query=[0.2, 0.8, ...],  # <-- dense vector\n        limit=50\n    ),\n    query=models.FormulaQuery(\n        formula=models.SumExpression(sum=[\n            \"$score\",\n            models.GaussDecayExpression(\n                gauss_decay=models.DecayParamsExpression(\n                    x=models.GeoDistance(\n                        geo_distance=models.GeoDistanceParams(\n                            origin=models.GeoPoint(\n                                lat=52.504043,\n                                lon=13.393236\n                            ),  # Berlin\n                            to=\"geo.location\"\n                        )\n                    ),\n                    scale=5000  # 5km\n                )\n            )\n        ]),\n        defaults={\"geo.location\": models.GeoPoint(lat=48.137154, lon=11.576124)}  # Munich\n    )\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    Condition, DecayParamsExpressionBuilder, Expression, FormulaBuilder, Fusion, GeoPoint,\n    PointId, PrefetchQueryBuilder, Query, QueryPointsBuilder, RecommendInputBuilder,\n    Sample,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\n// Query nearest by ID\nlet _nearest = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(PointId::from(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"))\n).await?;\n\n// Recommend on the average of these vectors\nlet _recommendations = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(Query::new_recommend(\n            RecommendInputBuilder::default()\n                .add_positive(vec![0.1; 8])\n                .add_negative(PointId::from(0))\n        ))\n).await?;\n\n// Fusion query\nlet _hybrid = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![(1, 0.22), (42, 0.8)])\n            .using(\"sparse\")\n            .limit(20u64)\n        )\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .using(\"dense\")\n            .limit(20u64)\n        )\n        .query(Fusion::Rrf)\n).await?;\n\n// 2-stage query\nlet _refined = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n        )\n        .query(vec![\n            vec![0.1, 0.2],\n            vec![0.2, 0.1],\n            vec![0.8, 0.9],\n        ])\n        .using(\"colbert\")\n        .limit(10u64)\n).await?;\n\n// Random sampling (as of 1.11.0)\nlet _sampled = client\n    .query(\n        QueryPointsBuilder::new(\"{collection_name}\")\n            .query(Query::new_sample(Sample::Random))\n    )\n    .await?;\n\n// Score boost depending on payload conditions (as of 1.14.0)\nlet _tag_boosted = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n        )\n        .query(FormulaBuilder::new(Expression::sum_with([\n            Expression::score(),\n            Expression::mult_with([\n                Expression::constant(0.5),\n                Expression::condition(Condition::matches(\"tag\", [\"h1\", \"h2\", \"h3\", \"h4\"])),\n            ]),\n            Expression::mult_with([\n                Expression::constant(0.25),\n                Expression::condition(Condition::matches(\"tag\", [\"p\", \"li\"])),\n            ]),\n        ])))\n        .limit(10)\n    ).await?;\n\n// Score boost geographically closer points (as of 1.14.0)\nlet _geo_boosted = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n            .add_prefetch(\n                PrefetchQueryBuilder::default()\n                    .query(vec![0.01, 0.45, 0.67])\n                    .limit(100u64),\n            )\n            .query(\n                FormulaBuilder::new(Expression::sum_with([\n                    Expression::score(),\n                    Expression::exp_decay(\n                        DecayParamsExpressionBuilder::new(Expression::geo_distance_with(\n                            // Berlin\n                            GeoPoint { lat: 52.504043, lon: 13.393236 },\n                            \"geo.location\",\n                        ))\n                        .scale(5_000.0),\n                    ),\n                ]))\n                // Munich\n                .add_default(\"geo.location\", GeoPoint { lat: 48.137154, lon: 11.576124 }),\n            )\n            .limit(10),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.QueryFactory.fusion;\nimport static io.qdrant.client.QueryFactory.nearest;\nimport static io.qdrant.client.QueryFactory.recommend;\nimport static io.qdrant.client.VectorInputFactory.vectorInput;\n\nimport java.util.UUID;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\nimport io.qdrant.client.grpc.Points.Fusion;\nimport io.qdrant.client.grpc.Points.PrefetchQuery;\nimport io.qdrant.client.grpc.Points.QueryPoints;\nimport io.qdrant.client.grpc.Points.RecommendInput;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\n// Query nearest by ID\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setQuery(nearest(UUID.fromString(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")))\n            .build())\n    .get();\n\n// Recommend on the average of these vectors\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setQuery(\n                recommend(\n                    RecommendInput.newBuilder()\n                        .addPositive(vectorInput(UUID.fromString(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")))\n                        .addPositive(vectorInput(0.11f, 0.35f, 0.6f))\n                        .addNegative(vectorInput(0.01f, 0.45f, 0.67f))\n                        .build()))\n            .build())\n    .get();\n\n// Fusion query\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(List.of(0.22f, 0.8f), List.of(1, 42)))\n                    .setUsing(\"sparse\")\n                    .setLimit(20)\n                    .build())\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(List.of(0.01f, 0.45f, 0.67f)))\n                    .setUsing(\"dense\")\n                    .setLimit(20)\n                    .build())\n            .setQuery(fusion(Fusion.RRF))\n            .build())\n    .get();\n\n// 2-stage query\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(0.01f, 0.45f, 0.67f))\n                    .setLimit(100)\n                    .build())\n            .setQuery(\n                nearest(\n                    new float[][] {\n                      {0.1f, 0.2f},\n                      {0.2f, 0.1f},\n                      {0.8f, 0.9f}\n                    }))\n            .setUsing(\"colbert\")\n            .setLimit(10)\n            .build())\n    .get();\n\n// Random sampling (as of 1.11.0)\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setQuery(sample(Sample.Random))\n            .build())\n    .get();\n\n// Score boost depending on payload conditions (as of 1.14.0)\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(0.01f, 0.45f, 0.67f))\n                    .setLimit(100)\n                    .build())\n            .setQuery(\n                formula(\n                    Formula.newBuilder()\n                        .setExpression(\n                            sum(\n                                SumExpression.newBuilder()\n                                    .addSum(variable(\"$score\"))\n                                    .addSum(\n                                        mult(\n                                            MultExpression.newBuilder()\n                                                .addMult(constant(0.5f))\n                                                .addMult(\n                                                    condition(\n                                                        matchKeywords(\n                                                            \"tag\",\n                                                            List.of(\"h1\", \"h2\", \"h3\", \"h4\"))))\n                                                .build()))\n                                    .addSum(mult(MultExpression.newBuilder()\n                                    .addMult(constant(0.25f))\n                                    .addMult(\n                                        condition(\n                                            matchKeywords(\n                                                \"tag\",\n                                                List.of(\"p\", \"li\"))))\n                                    .build()))\n                                    .build()))\n                        .build()))\n            .build())\n    .get();\n\n// Score boost geographically closer points (as of 1.14.0)\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(0.01f, 0.45f, 0.67f))\n                    .setLimit(100)\n                    .build())\n            .setQuery(\n                formula(\n                    Formula.newBuilder()\n                        .setExpression(\n                            sum(\n                                SumExpression.newBuilder()\n                                    .addSum(variable(\"$score\"))\n                                    .addSum(\n                                        expDecay(\n                                            DecayParamsExpression.newBuilder()\n                                                .setX(\n                                                    geoDistance(\n                                                        GeoDistance.newBuilder()\n                                                            .setOrigin(\n                                                                GeoPoint.newBuilder()\n                                                                    .setLat(52.504043)\n                                                                    .setLon(13.393236)\n                                                                    .build())\n                                                            .setTo(\"geo.location\")\n                                                            .build()))\n                                                .setScale(5000)\n                                                .build()))\n                                    .build()))\n                        .putDefaults(\n                            \"geo.location\",\n                            value(\n                                Map.of(\n                                    \"lat\", value(48.137154),\n                                    \"lon\", value(11.576124))))\n                        .build()))\n            .build())\n    .get();\n"
               language: java
@@ -919,17 +925,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc query() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t// Query nearest by ID\n\tpoints, err := client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQueryID(qdrant.NewID(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t// Recommend on the average of these vectors\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewID(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")),\n\t\t\t\tqdrant.NewVectorInput(0.11, 0.35, 0.6),\n\t\t\t},\n\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInput(0.01, 0.45, 0.67),\n\t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t// Fusion query\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuerySparse([]uint32{1, 42}, []float32{0.22, 0.8}),\n\t\t\t\tUsing: qdrant.PtrOf(\"sparse\"),\n\t\t\t},\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t\tUsing: qdrant.PtrOf(\"dense\"),\n\t\t\t},\n\t\t},\n\t\tQuery: qdrant.NewQueryFusion(qdrant.Fusion_RRF),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t// 2-stage query\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t},\n\t\t},\n\t\tQuery: qdrant.NewQueryMulti([][]float32{\n\t\t\t{0.1, 0.2},\n\t\t\t{0.2, 0.1},\n\t\t\t{0.8, 0.9},\n\t\t}),\n\t\tUsing: qdrant.PtrOf(\"colbert\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t// Random sampling (as of 1.11.0)\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQuerySample(qdrant.Sample_Random),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t// Score boost depending on payload conditions (as of 1.14.0)\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t},\n\t\t},\n\t\tQuery: qdrant.NewQueryFormula(&qdrant.Formula{\n\t\t\tExpression: qdrant.NewExpressionSum(&qdrant.SumExpression{\n\t\t\t\tSum: []*qdrant.Expression{\n\t\t\t\t\tqdrant.NewExpressionVariable(\"$score\"),\n\t\t\t\t\tqdrant.NewExpressionMult(&qdrant.MultExpression{\n\t\t\t\t\t\tMult: []*qdrant.Expression{\n\t\t\t\t\t\t\tqdrant.NewExpressionConstant(0.5),\n\t\t\t\t\t\t\tqdrant.NewExpressionCondition(qdrant.NewMatchKeywords(\"tag\", \"h1\", \"h2\", \"h3\", \"h4\")),\n\t\t\t\t\t\t},\n\t\t\t\t\t}),\n\t\t\t\t\tqdrant.NewExpressionMult(&qdrant.MultExpression{\n\t\t\t\t\t\tMult: []*qdrant.Expression{\n\t\t\t\t\t\t\tqdrant.NewExpressionConstant(0.25),\n\t\t\t\t\t\t\tqdrant.NewExpressionCondition(qdrant.NewMatchKeywords(\"tag\", \"p\", \"li\")),\n\t\t\t\t\t\t},\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t}),\n\t\t}),\n\t})\n\n\t// Score boost geographically closer points (as of 1.14.0)\n\tclient.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.2, 0.8),\n\t\t\t},\n\t\t},\n\t\tQuery: qdrant.NewQueryFormula(&qdrant.Formula{\n\t\t\tExpression: qdrant.NewExpressionSum(&qdrant.SumExpression{\n\t\t\t\tSum: []*qdrant.Expression{\n\t\t\t\t\tqdrant.NewExpressionVariable(\"$score\"),\n\t\t\t\t\tqdrant.NewExpressionExpDecay(&qdrant.DecayParamsExpression{\n\t\t\t\t\t\tX: qdrant.NewExpressionGeoDistance(&qdrant.GeoDistance{\n\t\t\t\t\t\t\tOrigin: &qdrant.GeoPoint{\n\t\t\t\t\t\t\t\tLat: 52.504043,\n\t\t\t\t\t\t\t\tLon: 13.393236,\n\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\tTo: \"geo.location\",\n\t\t\t\t\t\t}),\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t}),\n\t\t\tDefaults: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\"geo.location\": map[string]any{\n\t\t\t\t\t\"lat\": 48.137154,\n\t\t\t\t\t\"lon\": 11.576124,\n\t\t\t\t},\n\t\t\t}),\n\t\t}),\n\t})\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n// Query nearest by ID\nlet _nearest = client.query(\"{collection_name\", {\n    query: \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\n});\n\n// Recommend on the average of these vectors\nlet _recommendations = client.query(\"{collection_name}\", {\n    query: {\n        recommend: {\n            positive: [\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\", [0.11, 0.35, 0.6]],\n            negative: [0.01, 0.45, 0.67]\n        }\n    }\n});\n\n// Fusion query\nlet _hybrid = client.query(\"{collection_name}\", {\n    prefetch: [\n        {\n            query: {\n                values: [0.22, 0.8],\n                indices: [1, 42],\n            },\n            using: 'sparse',\n            limit: 20,\n        },\n        {\n            query: [0.01, 0.45, 0.67],\n            using: 'dense',\n            limit: 20,\n        },\n    ],\n    query: {\n        fusion: 'rrf',\n    },\n});\n\n// 2-stage query\nlet _refined = client.query(\"{collection_name}\", {\n    prefetch: {\n        query: [1, 23, 45, 67],\n        limit: 100,\n    },\n    query: [\n        [0.1, 0.2],\n        [0.2, 0.1],\n        [0.8, 0.9],\n    ],\n    using: 'colbert',\n    limit: 10,\n});\n\n// Random sampling (as of 1.11.0)\nlet _sampled = client.query(\"{collection_name}\", {\n  query: { sample: \"random\" },\n});\n\n// Score boost depending on payload conditions (as of 1.14.0)\nconst tag_boosted = await client.query(\"{collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, 0.1, 0.9],\n    limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n        \"$score\",\n        {\n          mult: [ 0.5, { key: \"tag\", match: { any: [\"h1\", \"h2\", \"h3\", \"h4\"] }} ]\n        },\n        {\n          mult: [ 0.25, { key: \"tag\", match: { any: [\"p\", \"li\"] }} ]\n        }\n      ]\n    }\n  }\n});\n\n// Score boost geographically closer points (as of 1.14.0)\nconst distance_boosted = await client.query(\"{collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, ...],\n    limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n        \"$score\",\n        {\n          gauss_decay: {\n            x: {\n              geo_distance: {\n                origin: { lat: 52.504043, lon: 13.393236 }, // Berlin\n                to: \"geo.location\"\n              }\n            },\n            scale: 5000 // 5km\n          }\n        }\n      ]\n    },\n    defaults: { \"geo.location\": { lat: 48.137154, lon: 11.576124 } } // Munich\n  }\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    Condition, DecayParamsExpressionBuilder, Expression, FormulaBuilder, Fusion, GeoPoint,\n    PointId, PrefetchQueryBuilder, Query, QueryPointsBuilder, RecommendInputBuilder,\n    Sample,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\n// Query nearest by ID\nlet _nearest = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(PointId::from(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"))\n).await?;\n\n// Recommend on the average of these vectors\nlet _recommendations = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(Query::new_recommend(\n            RecommendInputBuilder::default()\n                .add_positive(vec![0.1; 8])\n                .add_negative(PointId::from(0))\n        ))\n).await?;\n\n// Fusion query\nlet _hybrid = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![(1, 0.22), (42, 0.8)])\n            .using(\"sparse\")\n            .limit(20u64)\n        )\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .using(\"dense\")\n            .limit(20u64)\n        )\n        .query(Fusion::Rrf)\n).await?;\n\n// 2-stage query\nlet _refined = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n        )\n        .query(vec![\n            vec![0.1, 0.2],\n            vec![0.2, 0.1],\n            vec![0.8, 0.9],\n        ])\n        .using(\"colbert\")\n        .limit(10u64)\n).await?;\n\n// Random sampling (as of 1.11.0)\nlet _sampled = client\n    .query(\n        QueryPointsBuilder::new(\"{collection_name}\")\n            .query(Query::new_sample(Sample::Random))\n    )\n    .await?;\n\n// Score boost depending on payload conditions (as of 1.14.0)\nlet _tag_boosted = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n        )\n        .query(FormulaBuilder::new(Expression::sum_with([\n            Expression::score(),\n            Expression::mult_with([\n                Expression::constant(0.5),\n                Expression::condition(Condition::matches(\"tag\", [\"h1\", \"h2\", \"h3\", \"h4\"])),\n            ]),\n            Expression::mult_with([\n                Expression::constant(0.25),\n                Expression::condition(Condition::matches(\"tag\", [\"p\", \"li\"])),\n            ]),\n        ])))\n        .limit(10)\n    ).await?;\n\n// Score boost geographically closer points (as of 1.14.0)\nlet _geo_boosted = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\")\n            .add_prefetch(\n                PrefetchQueryBuilder::default()\n                    .query(vec![0.01, 0.45, 0.67])\n                    .limit(100u64),\n            )\n            .query(\n                FormulaBuilder::new(Expression::sum_with([\n                    Expression::score(),\n                    Expression::exp_decay(\n                        DecayParamsExpressionBuilder::new(Expression::geo_distance_with(\n                            // Berlin\n                            GeoPoint { lat: 52.504043, lon: 13.393236 },\n                            \"geo.location\",\n                        ))\n                        .scale(5_000.0),\n                    ),\n                ]))\n                // Munich\n                .add_default(\"geo.location\", GeoPoint { lat: 48.137154, lon: 11.576124 }),\n            )\n            .limit(10),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\n// Query nearest by ID\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tquery: Guid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")\n);\n\n// Recommend on the average of these vectors\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tquery: new RecommendInput\n\t{\n\t\tPositive =\n\t\t{\n\t\t\tGuid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"),\n\t\t\tnew float[] { 0.11f, 0.35f, 0.6f }\n\t\t},\n\t\tNegative = { new float[] { 0.01f, 0.45f, 0.67f } }\n\t}\n);\n\n// Fusion query\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch: new List<PrefetchQuery>\n\t{\n\t\tnew()\n\t\t{\n\t\t\tQuery = new (float, uint)[] { (0.22f, 1), (0.8f, 42), },\n\t\t\tUsing = \"sparse\",\n\t\t\tLimit = 20\n\t\t},\n\t\tnew()\n\t\t{\n\t\t\tQuery = new float[] { 0.01f, 0.45f, 0.67f },\n\t\t\tUsing = \"dense\",\n\t\t\tLimit = 20\n\t\t}\n\t},\n\tquery: Fusion.Rrf\n);\n\n// 2-stage query\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch: new List<PrefetchQuery>\n\t{\n\t\tnew() { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 }\n\t},\n\tquery: new float[][] { [0.1f, 0.2f], [0.2f, 0.1f], [0.8f, 0.9f] },\n\tusingVector: \"colbert\",\n\tlimit: 10\n);\n\n// Random sampling (as of 1.11.0)\nawait client.QueryAsync(\n    collectionName: \"{collection_name}\",\n    query: Sample.Random\n);\n\n// Score boost depending on payload conditions (as of 1.14.0)\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\tExpression = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"$score\",\n\t\t\t\tnew MultExpression\n\t\t\t\t{\n\t\t\t\t\tMult = { 0.5f, Match(\"tag\", [\"h1\", \"h2\", \"h3\", \"h4\"]) },\n\t\t\t\t},\n\t\t\t\tnew MultExpression { Mult = { 0.25f, Match(\"tag\", [\"p\", \"li\"]) } },\n\t\t\t},\n\t\t},\n\t},\n\tlimit: 10\n);\n\n// Score boost geographically closer points (as of 1.14.0)\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\tExpression = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"$score\",\n\t\t\t\tWithExpDecay(\n\t\t\t\t\tnew()\n\t\t\t\t\t{\n\t\t\t\t\t\tX = new GeoDistance\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\tOrigin = new GeoPoint { Lat = 52.504043, Lon = 13.393236 },\n\t\t\t\t\t\t\tTo = \"geo.location\",\n\t\t\t\t\t\t},\n\t\t\t\t\t\tScale = 5000,\n\t\t\t\t\t}\n\t\t\t\t),\n\t\t\t},\n\t\t},\n\t\tDefaults =\n\t\t{\n\t\t\t[\"geo.location\"] = new Dictionary<string, Value>\n\t\t\t{\n\t\t\t\t[\"lat\"] = 48.137154,\n\t\t\t\t[\"lon\"] = 11.576124,\n\t\t\t},\n\t\t},\n\t}\n);\n"
-              language: csharp
-        - code-samples:
             - code: "# Query nearest by ID\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"query\": \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\n}'\n\n# Recommend on the average of these vectors\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"query\": {\n    \"recommend\": {\n      \"positive\": [\n        [\n          0.11,\n          0.35,\n          0.6\n        ]\n      ],\n      \"negative\": [\n        \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\",\n        [\n          0.01,\n          0.45,\n          0.67\n        ]\n      ]\n    }\n  }\n}'\n\n# Fusion query\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"prefetch\": [\n    {\n      \"query\": {\n        \"values\": [\n          0.22,\n          0.8\n        ],\n        \"indices\": [\n          1,\n          42\n        ]\n      },\n      \"using\": \"sparse\",\n      \"limit\": 20\n    },\n    {\n      \"query\": [\n        0.01,\n        0.45,\n        0.67\n      ],\n      \"using\": \"dense\",\n      \"limit\": 20\n    }\n  ],\n  \"query\": {\n    \"fusion\": \"rrf\"\n  }\n}'\n\n# 2-stage query\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"prefetch\": {\n    \"query\": [\n      1,\n      23,\n      45,\n      67\n    ],\n    \"limit\": 100\n  },\n  \"query\": [\n    [\n      0.1,\n      0.2,\n      0.3\n    ],\n    [\n      0.2,\n      0.1,\n      0.35\n    ],\n    [\n      0.8,\n      0.9,\n      0.53\n    ]\n  ],\n  \"using\": \"colbert\",\n  \"limit\": 10\n}'\n\n# Random sampling (as of 1.11.0)\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"query\": {\n    \"sample\": \"random\"\n  }\n}'\n\n# Score boost depending on payload conditions (as of 1.14.0)\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n    \"prefetch\": {\n        \"query\": [0.2, 0.8, ...],  // <-- dense vector\n        \"limit\": 50\n    }\n    \"query\": {\n        \"formula\": {\n            \"sum\": [\n                \"$score,\n                { \"mult\": [ 0.5, { \"key\": \"tag\", \"match\": { \"any\": [\"h1\", \"h2\", \"h3\", \"h4\"] } } ] },\n                { \"mult\": [ 0.25, { \"key\": \"tag\", \"match\": { \"any\": [\"p\", \"li\"] } } ] }\n            ]\n        }\n    }\n}'\n\n# Score boost geographically closer points (as of 1.14.0)\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n    \"prefetch\": { \"query\": [0.2, 0.8, ...], \"limit\": 50 },\n    \"query\": {\n        \"formula\": {\n            \"sum\": [\n                \"$score\",\n                {\n                    \"gauss_decay\": {\n                        \"x\": {\n                            \"geo_distance\": {\n                                \"origin\": { \"lat\": 52.504043, \"lon\": 13.393236 } // Berlin\n                                \"to\": \"geo.location\"\n                            }\n                        },\n                        \"scale\": 5000 // 5km\n                    }\n                }\n            ]\n        },\n        \"defaults\": { \"geo.location\": {\"lat\": 48.137154, \"lon\": 11.576124} } // Munich\n    }\n}'\n"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n// Query nearest by ID\nlet _nearest = client.query(\"{collection_name\", {\n    query: \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\n});\n\n// Recommend on the average of these vectors\nlet _recommendations = client.query(\"{collection_name}\", {\n    query: {\n        recommend: {\n            positive: [\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\", [0.11, 0.35, 0.6]],\n            negative: [0.01, 0.45, 0.67]\n        }\n    }\n});\n\n// Fusion query\nlet _hybrid = client.query(\"{collection_name}\", {\n    prefetch: [\n        {\n            query: {\n                values: [0.22, 0.8],\n                indices: [1, 42],\n            },\n            using: 'sparse',\n            limit: 20,\n        },\n        {\n            query: [0.01, 0.45, 0.67],\n            using: 'dense',\n            limit: 20,\n        },\n    ],\n    query: {\n        fusion: 'rrf',\n    },\n});\n\n// 2-stage query\nlet _refined = client.query(\"{collection_name}\", {\n    prefetch: {\n        query: [1, 23, 45, 67],\n        limit: 100,\n    },\n    query: [\n        [0.1, 0.2],\n        [0.2, 0.1],\n        [0.8, 0.9],\n    ],\n    using: 'colbert',\n    limit: 10,\n});\n\n// Random sampling (as of 1.11.0)\nlet _sampled = client.query(\"{collection_name}\", {\n  query: { sample: \"random\" },\n});\n\n// Score boost depending on payload conditions (as of 1.14.0)\nconst tag_boosted = await client.query(\"{collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, 0.1, 0.9],\n    limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n        \"$score\",\n        {\n          mult: [ 0.5, { key: \"tag\", match: { any: [\"h1\", \"h2\", \"h3\", \"h4\"] }} ]\n        },\n        {\n          mult: [ 0.25, { key: \"tag\", match: { any: [\"p\", \"li\"] }} ]\n        }\n      ]\n    }\n  }\n});\n\n// Score boost geographically closer points (as of 1.14.0)\nconst distance_boosted = await client.query(\"{collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, ...],\n    limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n        \"$score\",\n        {\n          gauss_decay: {\n            x: {\n              geo_distance: {\n                origin: { lat: 52.504043, lon: 13.393236 }, // Berlin\n                to: \"geo.location\"\n              }\n            },\n            scale: 5000 // 5km\n          }\n        }\n      ]\n    },\n    defaults: { \"geo.location\": { lat: 48.137154, lon: 11.576124 } } // Munich\n  }\n});\n"
+              language: typescript
       description: Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
       summary: Query points
       tags:
@@ -938,8 +938,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.QueryBatchAsync(\n\tcollectionName: \"{collection_name}\",\n\tqueries: new List<QueryPoints>\n\t{\n\t\tnew() { Query = new float[] { 0.1f, 0.2f, 0.3f }, },\n\t\tnew() { Query = new float[] { 0.4f, 0.5f, 0.6f }, }\n\t}\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nnearest = client.query_batch_points(\n    collection_name=\"{collection_name}\",\n    requests=[\n        models.QueryRequest(\n            query=[0.01, 0.45, 0.67, ...],\n        ),\n        models.QueryRequest(\n            query=[0.11, 0.35, 0.6, ...],\n        ),\n    ]\n)"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::{Qdrant, QdrantError};\nuse qdrant_client::qdrant::{Query, QueryPointsBuilder, QueryBatchPointsBuilder};\n\nlet request = QueryBatchPointsBuilder::new(\"{collection_name}\", vec![\n    QueryPointsBuilder::new(\"\")\n        .query(Query::new_nearest(\n            vec![0.1; 8],\n        )).into(),\n    QueryPointsBuilder::new(\"\")\n        .query(Query::new_nearest(\n            vec![0.3; 8],\n        )).into(),\n]);\n\nlet response = client.query_batch(request).await?;"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.QueryFactory.nearest;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\nimport io.qdrant.client.grpc.Points.QueryPoints;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .queryBatchAsync(\n        \"{collection_name}\",\n        List.of(\n            QueryPoints.newBuilder().setQuery(nearest(0.1f, 0.2f, 0.3f)).build(),\n            QueryPoints.newBuilder().setQuery(nearest(0.4f, 0.5f, 0.6f)).build()))\n    .get();\n"
               language: java
@@ -947,17 +953,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc queryBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(), &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.11, 0.35, 0.6),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.queryBatch(\"{collection_name\", {\n    searches: [{\n        query: [0.01, 0.45, 0.67]\n    },\n    {\n        query: [0.11, 0.35, 0.6]\n    }]\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::{Qdrant, QdrantError};\nuse qdrant_client::qdrant::{Query, QueryPointsBuilder, QueryBatchPointsBuilder};\n\nlet request = QueryBatchPointsBuilder::new(\"{collection_name}\", vec![\n    QueryPointsBuilder::new(\"\")\n        .query(Query::new_nearest(\n            vec![0.1; 8],\n        )).into(),\n    QueryPointsBuilder::new(\"\")\n        .query(Query::new_nearest(\n            vec![0.3; 8],\n        )).into(),\n]);\n\nlet response = client.query_batch(request).await?;"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.QueryBatchAsync(\n\tcollectionName: \"{collection_name}\",\n\tqueries: new List<QueryPoints>\n\t{\n\t\tnew() { Query = new float[] { 0.1f, 0.2f, 0.3f }, },\n\t\tnew() { Query = new float[] { 0.4f, 0.5f, 0.6f }, }\n\t}\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query/batch' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n      \"query\": [\n        0.23,\n        0.325,\n        0.623\n      ],\n      \"limit\": 1\n    },\n    {\n      \"query\": [\n        0.423,\n        0.23,\n        0.623\n      ],\n      \"limit\": 5,\n      \"using\": \"image-vector\"\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.queryBatch(\"{collection_name\", {\n    searches: [{\n        query: [0.01, 0.45, 0.67]\n    },\n    {\n        query: [0.11, 0.35, 0.6]\n    }]\n});\n"
+              language: typescript
       description: Universally query points in batch. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
       summary: Query points in batch
       tags:
@@ -966,8 +966,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.QueryGroupsAsync(\n  collectionName: \"{collection_name}\",\n  groupBy: \"document_id\",\n  groupSize: 5,\n  limit: 10,\n  query: new float[] {\n    0.01f, 0.45f, 0.67f\n  }\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.query_points_groups(\n    collection_name=\"{collection_name}\",\n    query=[0.01, 0.45, 0.67],\n    group_by=\"document_id\",\n    limit=10,\n    group_size=5,\n)"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::Qdrant;\nuse qdrant_client::qdrant::{Query, QueryPointGroupsBuilder};\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient.query_groups(\n    QueryPointGroupsBuilder::new(\"{collection_name}\", \"document_id\")\n        .query(Query::from(vec![0.01, 0.45, 0.67]))\n        .limit(10u64)\n        .group_size(5u64)\n).await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.QueryFactory.nearest;\n\nimport io.qdrant.client.grpc.Points.QueryPointGroups;\nimport io.qdrant.client.grpc.Points.QueryPoints;\n\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .queryGroupsAsync(\n        QueryPointGroups.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setGroupBy(\"document_id\")\n            .setGroupSize(5)\n            .setLimit(10)\n            .setQuery(nearest(List.of(0.01f, 0.45f, 0.67f)))\n            .build())\n    .get();\n"
               language: java
@@ -975,17 +981,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc queryGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tgroupSize := uint64(5)\n\tresults, err := client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\tGroupBy:        \"document_id\",\n\t\tGroupSize:      &groupSize,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.queryGroups(\"{collection_name}\", {\n    query: [0.01, 0.45, 0.67],\n    group_by: \"document_id\",\n    limit: 10,\n    group_size: 5,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::Qdrant;\nuse qdrant_client::qdrant::{Query, QueryPointGroupsBuilder};\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient.query_groups(\n    QueryPointGroupsBuilder::new(\"{collection_name}\", \"document_id\")\n        .query(Query::from(vec![0.01, 0.45, 0.67]))\n        .limit(10u64)\n        .group_size(5u64)\n).await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.QueryGroupsAsync(\n  collectionName: \"{collection_name}\",\n  groupBy: \"document_id\",\n  groupSize: 5,\n  limit: 10,\n  query: new float[] {\n    0.01f, 0.45f, 0.67f\n  }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query/groups' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"query\": [\n    0.324,\n    0.643,\n    0.423\n  ],\n  \"group_by\": \"document_id\",\n  \"limit\": 1,\n  \"group_size\": 5\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.queryGroups(\"{collection_name}\", {\n    query: [0.01, 0.45, 0.67],\n    group_by: \"document_id\",\n    limit: 10,\n    group_size: 5,\n});\n"
+              language: typescript
       description: Universally query points and group results by a specified payload field. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
       summary: Query point groups
       tags:
@@ -994,8 +994,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendAsync(\n    \"{collection_name}\",\n    positive: new ulong[] { 100, 231 },\n    negative: new ulong[] { 718 },\n    filter: MatchKeyword(\"city\", \"London\"),\n    limit: 3\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.recommend(\n    collection_name=\"{collection_name}\",\n    positive=[100, 231],\n    negative=[718, [0.2, 0.3, 0.4, 0.5]],\n    strategy=models.RecommendStrategy.AVERAGE_VECTOR,\n    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n                key=\"city\",\n                match=models.MatchValue(\n                    value=\"London\",\n                ),\n            )\n        ]\n    ),\n    limit=3,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, Filter, RecommendPointsBuilder, RecommendStrategy};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .recommend(\n        RecommendPointsBuilder::new(\"{collection_name}\", 3)\n            .add_positive(100)\n            .add_positive(200)\n            .add_positive(vec![100.0, 231.0])\n            .add_negative(718)\n            .add_negative(vec![0.2, 0.3, 0.4, 0.5])\n            .strategy(RecommendStrategy::AverageVector)\n            .filter(Filter::must([Condition::matches(\n                \"city\",\n                \"London\".to_string(),\n            )])),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\nimport static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.RecommendPoints;\nimport io.qdrant.client.grpc.Points.RecommendStrategy;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .recommendAsync(\n        RecommendPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addAllPositive(List.of(id(100), id(200)))\n            .addAllPositiveVectors(List.of(vector(100.0f, 231.0f)))\n            .addAllNegative(List.of(id(718)))\n            .addAllPositiveVectors(List.of(vector(0.2f, 0.3f, 0.4f, 0.5f)))\n            .setStrategy(RecommendStrategy.AverageVector)\n            .setFilter(Filter.newBuilder().addMust(matchKeyword(\"city\", \"London\")))\n            .setLimit(3)\n            .build())\n    .get();\n"
               language: java
@@ -1003,17 +1009,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc recommend() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t},\n\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\t\t\tqdrant.NewVectorInput(0.2, 0.3, 0.4, 0.5),\n\t\t\t},\n\t\t\tStrategy: qdrant.RecommendStrategy_AverageVector.Enum(),\n\t\t}),\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"city\", \"London\"),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recommend(\"{collection_name}\", {\n    positive: [100, 231],\n    negative: [718, [0.2, 0.3, 0.4, 0.5]],\n    strategy: \"average_vector\",\n    filter: {\n        must: [\n            {\n                key: \"city\",\n                match: {\n                    value: \"London\",\n                },\n            },\n        ],\n    },\n    limit: 3,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, Filter, RecommendPointsBuilder, RecommendStrategy};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .recommend(\n        RecommendPointsBuilder::new(\"{collection_name}\", 3)\n            .add_positive(100)\n            .add_positive(200)\n            .add_positive(vec![100.0, 231.0])\n            .add_negative(718)\n            .add_negative(vec![0.2, 0.3, 0.4, 0.5])\n            .strategy(RecommendStrategy::AverageVector)\n            .filter(Filter::must([Condition::matches(\n                \"city\",\n                \"London\".to_string(),\n            )])),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendAsync(\n    \"{collection_name}\",\n    positive: new ulong[] { 100, 231 },\n    negative: new ulong[] { 718 },\n    filter: MatchKeyword(\"city\", \"London\"),\n    limit: 3\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"positive\": [\n    100,\n    231\n  ],\n  \"negative\": [\n    \"3a6e2150-f7b7-496e-92cd-687e63e215fd\",\n    [\n      0.2,\n      0.3,\n      0.4,\n      0.5\n    ]\n  ],\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"city\",\n        \"match\": {\n          \"value\": \"London\"\n        }\n      }\n    ]\n  },\n  \"limit\": 1\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recommend(\"{collection_name}\", {\n    positive: [100, 231],\n    negative: [718, [0.2, 0.3, 0.4, 0.5]],\n    strategy: \"average_vector\",\n    filter: {\n        must: [\n            {\n                key: \"city\",\n                match: {\n                    value: \"London\",\n                },\n            },\n        ],\n    },\n    limit: 3,\n});\n"
+              language: typescript
       description: Retrieves points that are closer to stored positive examples and further from negative examples.
       summary: Recommend points
       tags:
@@ -1022,8 +1022,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter = MatchKeyword(\"city\", \"london\");\n\nawait client.RecommendBatchAsync(\n  collectionName: \"{collection_name}\",\n  recommendSearches:\n  [\n    new()\n    {\n      CollectionName = \"{collection_name}\",\n      Positive = { new PointId[] { 100, 231 } },\n      Negative = { new PointId[] { 718 } },\n      Limit = 3,\n      Filter = filter,\n    },\n    new()\n    {\n      CollectionName = \"{collection_name}\",\n      Positive = { new PointId[] { 200, 67 } },\n      Negative = { new PointId[] { 300 } },\n      Limit = 3,\n      Filter = filter,\n    }\n  ]\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nrecommend_queries = [\n    models.RecommendRequest(\n        positive=[100, 231], negative=[718], filter=filter_, limit=3\n    ),\n    models.RecommendRequest(positive=[200, 67], negative=[300], limit=3),\n]\n\nclient.recommend_batch(collection_name=\"{collection_name}\", requests=recommend_queries)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    Condition, Filter, RecommendBatchPointsBuilder, RecommendPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\nlet recommend_queries = vec![\n    RecommendPointsBuilder::new(\"{collection_name}\", 3)\n        .add_positive(100)\n        .add_positive(231)\n        .add_negative(718)\n        .filter(filter.clone())\n        .build(),\n    RecommendPointsBuilder::new(\"{collection_name}\", 3)\n        .add_positive(200)\n        .add_positive(67)\n        .add_negative(300)\n        .filter(filter.clone())\n        .build(),\n];\n\nclient\n    .recommend_batch(RecommendBatchPointsBuilder::new(\n        \"{collection_name}\",\n        recommend_queries,\n    ))\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\nimport static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.RecommendPoints;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nFilter filter = Filter.newBuilder().addMust(matchKeyword(\"city\", \"London\")).build();\n\nList<RecommendPoints> recommendQueries =\n    List.of(\n        RecommendPoints.newBuilder()\n            .addAllPositive(List.of(id(100), id(231)))\n            .addAllNegative(List.of(id(718)))\n            .setFilter(filter)\n            .setLimit(3)\n            .build(),\n        RecommendPoints.newBuilder()\n            .addAllPositive(List.of(id(200), id(67)))\n            .addAllNegative(List.of(id(300)))\n            .setFilter(filter)\n            .setLimit(3)\n            .build());\n\nclient.recommendBatchAsync(\"{collection_name}\", recommendQueries, null).get();\n"
               language: java
@@ -1031,17 +1037,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc recommendBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(), &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t\t\t},\n\t\t\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(67)),\n\t\t\t\t\t},\n\t\t\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst searches = [\n    {\n        positive: [100, 231],\n        negative: [718],\n        limit: 3,\n    },\n    {\n        positive: [200, 67],\n        negative: [300],\n        limit: 3,\n    },\n];\n\nclient.recommend_batch(\"{collection_name}\", {\n    searches,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    Condition, Filter, RecommendBatchPointsBuilder, RecommendPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\nlet recommend_queries = vec![\n    RecommendPointsBuilder::new(\"{collection_name}\", 3)\n        .add_positive(100)\n        .add_positive(231)\n        .add_negative(718)\n        .filter(filter.clone())\n        .build(),\n    RecommendPointsBuilder::new(\"{collection_name}\", 3)\n        .add_positive(200)\n        .add_positive(67)\n        .add_negative(300)\n        .filter(filter.clone())\n        .build(),\n];\n\nclient\n    .recommend_batch(RecommendBatchPointsBuilder::new(\n        \"{collection_name}\",\n        recommend_queries,\n    ))\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter = MatchKeyword(\"city\", \"london\");\n\nawait client.RecommendBatchAsync(\n  collectionName: \"{collection_name}\",\n  recommendSearches:\n  [\n    new()\n    {\n      CollectionName = \"{collection_name}\",\n      Positive = { new PointId[] { 100, 231 } },\n      Negative = { new PointId[] { 718 } },\n      Limit = 3,\n      Filter = filter,\n    },\n    new()\n    {\n      CollectionName = \"{collection_name}\",\n      Positive = { new PointId[] { 200, 67 } },\n      Negative = { new PointId[] { 300 } },\n      Limit = 3,\n      Filter = filter,\n    }\n  ]\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend/batch' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n      \"positive\": [\n        100,\n        231\n      ],\n      \"negative\": [\n        \"9ad0884a-7bfe-43c0-b88f-c1d9a588b7e1\"\n      ],\n      \"limit\": 1\n    },\n    {\n      \"positive\": [\n        200,\n        67\n      ],\n      \"negative\": [\n        300\n      ],\n      \"limit\": 5\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst searches = [\n    {\n        positive: [100, 231],\n        negative: [718],\n        limit: 3,\n    },\n    {\n        positive: [200, 67],\n        negative: [300],\n        limit: 3,\n    },\n];\n\nclient.recommend_batch(\"{collection_name}\", {\n    searches,\n});\n"
+              language: typescript
       description: Retrieves points in batches that are closer to stored positive examples and further from negative examples.
       summary: Recommend batch points
       tags:
@@ -1050,8 +1050,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendGroupsAsync(\n    \"{collection_name}\",\n    \"document_id\",\n    groupSize: 3,\n    positive: new ulong[] { 100, 231 },\n    negative: new ulong[] { 718 },\n    filter: MatchKeyword(\"city\", \"London\"),\n    limit: 3\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.recommend_groups(\n    collection_name=\"{collection_name}\",\n    positive=[100, 231],\n    negative=[718],\n    group_by=\"document_id\",\n    limit=3,\n    group_size=2,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{RecommendPointGroupsBuilder, RecommendStrategy};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .recommend_groups(\n        RecommendPointGroupsBuilder::new(\"{collection_name}\", \"document_id\", 2, 3)\n            .add_positive(100)\n            .add_positive(200)\n            .add_negative(718)\n            .strategy(RecommendStrategy::AverageVector),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.RecommendPointGroups;\nimport io.qdrant.client.grpc.Points.RecommendStrategy;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.recommendGroupsAsync(RecommendPointGroups.newBuilder()\n                .setCollectionName(\"{collection_name}\")\n                .setGroupBy(\"document_id\")\n                .setGroupSize(2)\n                .addAllPositive(List.of(id(100), id(200)))\n                .addAllNegative(List.of(id(718)))\n                .setStrategy(RecommendStrategy.AverageVector)\n                .setLimit(3)\n                .build());\n"
               language: java
@@ -1059,17 +1065,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc recommendGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tgroupSize := uint64(5)\n\tresults, err := client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t},\n\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\t\t},\n\t\t}),\n\t\tGroupBy:   \"document_id\",\n\t\tGroupSize: &groupSize,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recommendPointGroups(\"{collection_name}\", {\n    positive: [100, 231],\n    negative: [718],\n    group_by: \"document_id\",\n    limit: 3,\n    group_size: 2,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{RecommendPointGroupsBuilder, RecommendStrategy};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .recommend_groups(\n        RecommendPointGroupsBuilder::new(\"{collection_name}\", \"document_id\", 2, 3)\n            .add_positive(100)\n            .add_positive(200)\n            .add_negative(718)\n            .strategy(RecommendStrategy::AverageVector),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendGroupsAsync(\n    \"{collection_name}\",\n    \"document_id\",\n    groupSize: 3,\n    positive: new ulong[] { 100, 231 },\n    negative: new ulong[] { 718 },\n    filter: MatchKeyword(\"city\", \"London\"),\n    limit: 3\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend/groups' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"positive\": [\n    100,\n    231\n  ],\n  \"negative\": [\n    718\n  ],\n  \"group_by\": \"document_id\",\n  \"limit\": 3,\n  \"group_size\": 2\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recommendPointGroups(\"{collection_name}\", {\n    positive: [100, 231],\n    negative: [718],\n    group_by: \"document_id\",\n    limit: 3,\n    group_size: 2,\n});\n"
+              language: typescript
       description: Retrieves points that are closer to stored positive examples and further from negative examples. Results are grouped by the specified payload field.
       summary: Recommend point groups
       tags:
@@ -1078,8 +1078,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.ScrollAsync(\n  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\", \"red\"),\n  limit: 1,\n  payloadSelector: true\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.scroll(\n    collection_name=\"{collection_name}\",\n    scroll_filter=models.Filter(\n        must=[\n            models.FieldCondition(key=\"color\", match=models.MatchValue(value=\"red\")),\n        ]\n    ),\n    limit=1,\n    with_payload=True,\n    with_vectors=False,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .scroll(\n        ScrollPointsBuilder::new(\"{collection_name}\")\n            .filter(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .limit(1)\n            .with_payload(true)\n            .with_vectors(false),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\nimport static io.qdrant.client.WithPayloadSelectorFactory.enable;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.ScrollPoints;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .scrollAsync(\n        ScrollPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setFilter(Filter.newBuilder().addMust(matchKeyword(\"color\", \"red\")).build())\n            .setLimit(1)\n            .setWithPayload(enable(true))\n            .build())\n    .get();\n"
               language: java
@@ -1087,17 +1093,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc scroll() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tlimit := uint32(1)\n\tresults, err := client.Scroll(context.Background(), &qdrant.ScrollPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t},\n\t\tLimit:       &limit,\n\t\tWithPayload: qdrant.NewWithPayloadEnable(true),\n\t\tWithVectors: qdrant.NewWithVectorsEnable(false),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.scroll(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    limit: 1,\n    with_payload: true,\n    with_vector: false,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .scroll(\n        ScrollPointsBuilder::new(\"{collection_name}\")\n            .filter(Filter::must([Condition::matches(\n                \"color\",\n                \"red\".to_string(),\n            )]))\n            .limit(1)\n            .with_payload(true)\n            .with_vectors(false),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.ScrollAsync(\n  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\", \"red\"),\n  limit: 1,\n  payloadSelector: true\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/scroll' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"with_payload\": [\n    \"city\",\n    \"color\"\n  ],\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"limit\": 2,\n  \"with_vector\": false\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.scroll(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    limit: 1,\n    with_payload: true,\n    with_vector: false,\n});\n"
+              language: typescript
       description: 'Returns all points in a page-by-page manner.
 
         By default, all resulting points are sorted by {id}.
@@ -1114,8 +1114,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchAsync(\n  collectionName: \"{collection_name}\",\n  vector: new float[] { 0.2f, 0.1f, 0.9f, 0.7f },\n  filter: MatchKeyword(\"city\", \"London\"),\n  limit: 3\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.search(\n    collection_name=\"{collection_name}\",\n    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n                key=\"city\",\n                match=models.MatchValue(\n                    value=\"London\",\n                ),\n            )\n        ]\n    ),\n    query_vector=[0.2, 0.1, 0.9, 0.7],\n    limit=3,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, Filter, SearchParamsBuilder, SearchPointsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_points(\n        SearchPointsBuilder::new(\"{collection_name}\", vec![0.2, 0.1, 0.9, 0.7], 3)\n            .filter(Filter::must([Condition::matches(\n                \"city\",\n                \"London\".to_string(),\n            )]))\n            .params(SearchParamsBuilder::default().hnsw_ef(128).exact(false)),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchPoints;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .searchAsync(\n        SearchPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setFilter(Filter.newBuilder().addMust(matchKeyword(\"city\", \"London\")).build())\n            .addAllVector(List.of(0.2f, 0.1f, 0.9f, 0.7f))\n            .setLimit(3)\n            .build())\n    .get();\n"
               language: java
@@ -1123,17 +1129,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc search() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tlimit := uint64(3)\n\tresults, err := client.Query(context.Background(), &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"city\", \"London\"),\n\t\t\t},\n\t\t},\n\t\tLimit: &limit,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.search(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"city\",\n                match: {\n                    value: \"London\",\n                },\n            },\n        ],\n    },\n    vector: [0.2, 0.1, 0.9, 0.7],\n    limit: 3,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, Filter, SearchParamsBuilder, SearchPointsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_points(\n        SearchPointsBuilder::new(\"{collection_name}\", vec![0.2, 0.1, 0.9, 0.7], 3)\n            .filter(Filter::must([Condition::matches(\n                \"city\",\n                \"London\".to_string(),\n            )]))\n            .params(SearchParamsBuilder::default().hnsw_ef(128).exact(false)),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchAsync(\n  collectionName: \"{collection_name}\",\n  vector: new float[] { 0.2f, 0.1f, 0.9f, 0.7f },\n  filter: MatchKeyword(\"city\", \"London\"),\n  limit: 3\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vector\": [\n    0.2,\n    0.1,\n    0.9,\n    0.7\n  ],\n  \"limit\": 1,\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"city\",\n        \"match\": {\n          \"value\": \"London\"\n        }\n      }\n    ]\n  }\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.search(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"city\",\n                match: {\n                    value: \"London\",\n                },\n            },\n        ],\n    },\n    vector: [0.2, 0.1, 0.9, 0.7],\n    limit: 3,\n});\n"
+              language: typescript
       description: Retrieves the closest points based on vector similarity and given filtering conditions.
       summary: Search points
       tags:
@@ -1142,8 +1142,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter = MatchKeyword(\"city\", \"London\");\n\nvar searches = new List<SearchPoints>\n{\n  new()\n  {\n    Vector = { new float[] { 0.2f, 0.1f, 0.9f, 0.7f } },\n    Filter = filter,\n    Limit = 3\n  },\n  new()\n  {\n    Vector = { new float[] { 0.5f, 0.3f, 0.2f, 0.3f } },\n    Filter = filter,\n    Limit = 3\n  }\n};\n\nawait client.SearchBatchAsync(collectionName: \"{collection_name}\", searches: searches);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nfilter_ = models.Filter(\n    must=[\n        models.FieldCondition(\n            key=\"city\",\n            match=models.MatchValue(\n                value=\"London\",\n            ),\n        )\n    ]\n)\n\nsearch_queries = [\n    models.SearchRequest(vector=[0.2, 0.1, 0.9, 0.7], filter=filter_, limit=3),\n    models.SearchRequest(vector=[0.5, 0.3, 0.2, 0.3], filter=filter_, limit=3),\n]\n\nclient.search_batch(collection_name=\"{collection_name}\", requests=search_queries)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{\n    Condition, Filter, SearchBatchPointsBuilder, SearchPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\n\nlet searches = vec![\n    SearchPointsBuilder::new(\"{collection_name}\", vec![0.2, 0.1, 0.9, 0.7], 3)\n        .filter(filter.clone())\n        .build(),\n    SearchPointsBuilder::new(\"{collection_name}\", vec![0.5, 0.3, 0.2, 0.3], 3)\n        .filter(filter.clone())\n        .build(),\n];\n\nclient\n    .search_batch_points(SearchBatchPointsBuilder::new(\"{collection_name}\", searches))\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchPoints;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nFilter filter = Filter.newBuilder().addMust(matchKeyword(\"city\", \"London\")).build();\nList<SearchPoints> searches =\n    List.of(\n        SearchPoints.newBuilder()\n            .addAllVector(List.of(0.2f, 0.1f, 0.9f, 0.7f))\n            .setFilter(filter)\n            .setLimit(3)\n            .build(),\n        SearchPoints.newBuilder()\n            .addAllVector(List.of(0.5f, 0.3f, 0.2f, 0.3f))\n            .setFilter(filter)\n            .setLimit(3)\n            .build());\nclient.searchBatchAsync(\"{collection_name}\", searches, null).get();\n"
               language: java
@@ -1151,17 +1157,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc searchBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tfilter := qdrant.Filter{\n\t\tMust: []*qdrant.Condition{\n\t\t\tqdrant.NewMatch(\"city\", \"London\"),\n\t\t},\n\t}\n\tlimit := uint64(3)\n\tresults, err := client.QueryBatch(context.Background(), &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),\n\t\t\t\tLimit:          &limit,\n\t\t\t\tFilter:         &filter,\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.5, 0.3, 0.2, 0.3),\n\t\t\t\tLimit:          &limit,\n\t\t\t\tFilter:         &filter,\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst filter = {\n    must: [\n        {\n            key: \"city\",\n            match: {\n                value: \"London\",\n            },\n        },\n    ],\n};\n\nconst searches = [\n    {\n        vector: [0.2, 0.1, 0.9, 0.7],\n        filter,\n        limit: 3,\n    },\n    {\n        vector: [0.5, 0.3, 0.2, 0.3],\n        filter,\n        limit: 3,\n    },\n];\n\nclient.searchBatch(\"{collection_name}\", {\n    searches,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{\n    Condition, Filter, SearchBatchPointsBuilder, SearchPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\n\nlet searches = vec![\n    SearchPointsBuilder::new(\"{collection_name}\", vec![0.2, 0.1, 0.9, 0.7], 3)\n        .filter(filter.clone())\n        .build(),\n    SearchPointsBuilder::new(\"{collection_name}\", vec![0.5, 0.3, 0.2, 0.3], 3)\n        .filter(filter.clone())\n        .build(),\n];\n\nclient\n    .search_batch_points(SearchBatchPointsBuilder::new(\"{collection_name}\", searches))\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter = MatchKeyword(\"city\", \"London\");\n\nvar searches = new List<SearchPoints>\n{\n  new()\n  {\n    Vector = { new float[] { 0.2f, 0.1f, 0.9f, 0.7f } },\n    Filter = filter,\n    Limit = 3\n  },\n  new()\n  {\n    Vector = { new float[] { 0.5f, 0.3f, 0.2f, 0.3f } },\n    Filter = filter,\n    Limit = 3\n  }\n};\n\nawait client.SearchBatchAsync(collectionName: \"{collection_name}\", searches: searches);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search/batch' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n      \"vector\": [\n        0.2,\n        0.1,\n        0.9,\n        0.7\n      ],\n      \"limit\": 3\n    },\n    {\n      \"vector\": [\n        0.5,\n        0.3,\n        0.2,\n        0.3\n      ],\n      \"filter\": {\n        \"must\": [\n          {\n            \"key\": \"city\",\n            \"match\": {\n              \"value\": \"London\"\n            }\n          }\n        ]\n      },\n      \"limit\": 3\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nconst filter = {\n    must: [\n        {\n            key: \"city\",\n            match: {\n                value: \"London\",\n            },\n        },\n    ],\n};\n\nconst searches = [\n    {\n        vector: [0.2, 0.1, 0.9, 0.7],\n        filter,\n        limit: 3,\n    },\n    {\n        vector: [0.5, 0.3, 0.2, 0.3],\n        filter,\n        limit: 3,\n    },\n];\n\nclient.searchBatch(\"{collection_name}\", {\n    searches,\n});\n"
+              language: typescript
       description: Retrieves the closest points in batches based on vector similarity and given filtering conditions.
       summary: Search batch points
       tags:
@@ -1170,8 +1170,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchGroupsAsync(\n  collectionName: \"{collection_name}\",\n  vector: new float[] { 1.1f },\n  groupBy: \"document_id\",\n  limit: 4,\n  groupSize: 2\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.search_groups(\n    collection_name=\"{collection_name}\",\n    query_vector=[1.1],\n    group_by=\"document_id\",\n    limit=4,\n    group_size=2,\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::SearchPointGroupsBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_groups(SearchPointGroupsBuilder::new(\n        \"{collection_name}\",\n        vec![1.1],\n        4,\n        \"document_id\",\n        2,\n    ))\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.SearchPointGroups;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .searchGroupsAsync(\n        SearchPointGroups.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .addAllVector(List.of(1.1f))\n            .setGroupBy(\"document_id\")\n            .setLimit(4)\n            .setGroupSize(2)\n            .build())\n    .get();\n"
               language: java
@@ -1179,17 +1185,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc searchGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tgroupSize := uint64(2)\n\tresults, err := client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\tGroupBy:        \"document_id\",\n\t\tGroupSize:      &groupSize,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", results)\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.searchPointGroups(\"{collection_name}\", {\n    vector: [1.1],\n    group_by: \"document_id\",\n    limit: 4,\n    group_size: 2,\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::SearchPointGroupsBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_groups(SearchPointGroupsBuilder::new(\n        \"{collection_name}\",\n        vec![1.1],\n        4,\n        \"document_id\",\n        2,\n    ))\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchGroupsAsync(\n  collectionName: \"{collection_name}\",\n  vector: new float[] { 1.1f },\n  groupBy: \"document_id\",\n  limit: 4,\n  groupSize: 2\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search/groups' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"vector\": [\n    0.2,\n    0.1,\n    0.9,\n    0.7\n  ],\n  \"group_by\": \"document_id\",\n  \"limit\": 4,\n  \"group_size\": 2\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.searchPointGroups(\"{collection_name}\", {\n    vector: [1.1],\n    group_by: \"document_id\",\n    limit: 4,\n    group_size: 2,\n});\n"
+              language: typescript
       description: Retrieves the closest points based on vector similarity and given filtering conditions, grouped by a given payload field.
       summary: Search point groups
       tags:
@@ -1198,8 +1198,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixOffsetsAsync(\n    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"),\n    sample: 100,\n    limit: 5\n);"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.search_matrix_offsets(\n    collection_name=\"{collection_name}\",\n    sample=100,\n    limit=5,\n    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n                key=\"color\", match=models.MatchValue(value=\"red\")\n            ),\n        ]\n    ),\n)"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_offsets(\n        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n           .filter(Filter::must(vec![Condition::matches(\n               \"color\",\n               \"red\".to_string(),\n           )]))\n           .sample(100)\n           .limit(5),\n    )\n    .await?;"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchMatrixPoints;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .searchMatrixOffsetsAsync(\n        SearchMatrixPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setFilter(\n                Filter.newBuilder()\n                    .addMust(matchKeyword(\"color\", \"red\"))\n                    .build()\n            )\n            .setSample(100)\n            .setLimit(5)\n            .build())\n    .get();\n"
               language: java
@@ -1209,12 +1215,6 @@ paths:
         - code-samples:
             - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.searchMatrixOffsets(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    sample: 100,\n    limit: 5,\n});\n"
               language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_offsets(\n        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n           .filter(Filter::must(vec![Condition::matches(\n               \"color\",\n               \"red\".to_string(),\n           )]))\n           .sample(100)\n           .limit(5),\n    )\n    .await?;"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixOffsetsAsync(\n    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"),\n    sample: 100,\n    limit: 5\n);"
-              language: csharp
       description: Retrieves sparse matrix of pairwise distances between points sampled from the collection. Output is a form of row and column offsets and list of distances.
       summary: Distance matrix offsets
       tags:
@@ -1223,8 +1223,14 @@ paths:
     post:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixPairsAsync(\n    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"),\n    sample: 100,\n    limit: 5\n);"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.search_matrix_pairs(\n    collection_name=\"{collection_name}\",\n    sample=100,\n    limit=5,\n    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n                key=\"color\", match=models.MatchValue(value=\"red\")\n            ),\n        ]\n    ),\n)"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_pairs(\n        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n           .filter(Filter::must(vec![Condition::matches(\n               \"color\",\n               \"red\".to_string(),\n           )]))\n           .sample(100)\n           .limit(5),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchMatrixPoints;\n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .searchMatrixPairsAsync(\n        SearchMatrixPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\")\n            .setFilter(\n                Filter.newBuilder()\n                    .addMust(matchKeyword(\"color\", \"red\"))\n                    .build()\n            )\n            .setSample(100)\n            .setLimit(5)\n            .build())\n    .get();\n"
               language: java
@@ -1234,12 +1240,6 @@ paths:
         - code-samples:
             - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.searchMatrixPairs(\"{collection_name}\", {\n    filter: {\n        must: [\n            {\n                key: \"color\",\n                match: {\n                    value: \"red\",\n                },\n            },\n        ],\n    },\n    sample: 100,\n    limit: 5,\n});"
               language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder, Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_pairs(\n        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n           .filter(Filter::must(vec![Condition::matches(\n               \"color\",\n               \"red\".to_string(),\n           )]))\n           .sample(100)\n           .limit(5),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixPairsAsync(\n    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"),\n    sample: 100,\n    limit: 5\n);"
-              language: csharp
       description: Retrieves sparse matrix of pairwise distances between points sampled from the collection. Output is a list of pairs of points and their distances.
       summary: Distance matrix pairs
       tags:
@@ -1248,8 +1248,14 @@ paths:
     put:
       x-fern-examples:
         - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateVectorsAsync(\n  collectionName: \"{collection_name}\",\n  points: new List<PointVectors>\n  {\n    new() { Id = 1, Vectors = (\"image\", new float[] { 0.1f, 0.2f, 0.3f, 0.4f }) },\n    new()\n    {\n      Id = 2,\n      Vectors = (\"text\", new float[] { 0.9f, 0.8f, 0.7f, 0.6f, 0.5f, 0.4f, 0.3f, 0.2f })\n    }\n  }\n);\n"
+              language: csharp
+        - code-samples:
             - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.update_vectors(\n    collection_name=\"{collection_name}\",\n    points=[\n        models.PointVectors(\n            id=1,\n            vector={\n                \"image\": [0.1, 0.2, 0.3, 0.4],\n            },\n        ),\n        models.PointVectors(\n            id=2,\n            vector={\n                \"text\": [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n            },\n        ),\n    ],\n)\n"
               language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{PointVectors, UpdatePointVectorsBuilder};\nuse qdrant_client::Qdrant;\nuse std::collections::HashMap;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_vectors(\n        UpdatePointVectorsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointVectors {\n                    id: Some(1.into()),\n                    vectors: Some(\n                        HashMap::from([(\"image\".to_string(), vec![0.1, 0.2, 0.3, 0.4])])\n                            .into(),\n                    ),\n                },\n                PointVectors {\n                    id: Some(2.into()),\n                    vectors: Some(\n                        HashMap::from([(\n                            \"text\".to_string(),\n                            vec![0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n                        )])\n                        .into(),\n                    ),\n                },\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
+              language: rust
         - code-samples:
             - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\nimport static io.qdrant.client.VectorsFactory.namedVectors;\n\nimport java.util.List;\nimport java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .updateVectorsAsync(\n        \"{collection_name}\",\n        List.of(\n            PointVectors.newBuilder()\n                .setId(id(1))\n                .setVectors(namedVectors(Map.of(\"image\", vector(List.of(0.1f, 0.2f, 0.3f, 0.4f)))))\n                .build(),\n            PointVectors.newBuilder()\n                .setId(id(2))\n                .setVectors(\n                    namedVectors(\n                        Map.of(\n                            \"text\", vector(List.of(0.9f, 0.8f, 0.7f, 0.6f, 0.5f, 0.4f, 0.3f, 0.2f)))))\n                .build()))\n    .get();\n"
               language: java
@@ -1257,17 +1263,11 @@ paths:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc updateVectors() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.UpdateVectors(context.Background(), &qdrant.UpdatePointVectors{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPoints: []*qdrant.PointVectors{\n\t\t\t{\n\t\t\t\tId: qdrant.NewIDNum(1),\n\t\t\t\tVectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{\n\t\t\t\t\t\"image\": qdrant.NewVector(0.1, 0.2, 0.3, 0.4),\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tId: qdrant.NewIDNum(2),\n\t\t\t\tVectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{\n\t\t\t\t\t\"text\": qdrant.NewVector(0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2),\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateVectors(\"{collection_name}\", {\n    points: [\n        {\n            id: 1,\n            vector: {\n                image: [0.1, 0.2, 0.3, 0.4],\n            },\n        },\n        {\n            id: 2,\n            vector: {\n                text: [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n            },\n        },\n    ],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{PointVectors, UpdatePointVectorsBuilder};\nuse qdrant_client::Qdrant;\nuse std::collections::HashMap;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .update_vectors(\n        UpdatePointVectorsBuilder::new(\n            \"{collection_name}\",\n            vec![\n                PointVectors {\n                    id: Some(1.into()),\n                    vectors: Some(\n                        HashMap::from([(\"image\".to_string(), vec![0.1, 0.2, 0.3, 0.4])])\n                            .into(),\n                    ),\n                },\n                PointVectors {\n                    id: Some(2.into()),\n                    vectors: Some(\n                        HashMap::from([(\n                            \"text\".to_string(),\n                            vec![0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n                        )])\n                        .into(),\n                    ),\n                },\n            ],\n        )\n        .wait(true),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateVectorsAsync(\n  collectionName: \"{collection_name}\",\n  points: new List<PointVectors>\n  {\n    new() { Id = 1, Vectors = (\"image\", new float[] { 0.1f, 0.2f, 0.3f, 0.4f }) },\n    new()\n    {\n      Id = 2,\n      Vectors = (\"text\", new float[] { 0.9f, 0.8f, 0.7f, 0.6f, 0.5f, 0.4f, 0.3f, 0.2f })\n    }\n  }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/vectors?wait=true' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"points\": [\n    {\n      \"id\": 1,\n      \"vector\": [\n        0.0984,\n        0.1406,\n        0.8973\n      ]\n    },\n    {\n      \"id\": 2,\n      \"vector\": {\n        \"vector-name\": [\n          0.9,\n          0.8,\n          0.7,\n          0.6\n        ]\n      }\n    }\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.updateVectors(\"{collection_name}\", {\n    points: [\n        {\n            id: 1,\n            vector: {\n                image: [0.1, 0.2, 0.3, 0.4],\n            },\n        },\n        {\n            id: 2,\n            vector: {\n                text: [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n            },\n        },\n    ],\n});\n"
+              language: typescript
       description: Updates specified vectors on points. All other unspecified vectors will stay intact.
       summary: Update vectors
       tags:
@@ -1275,21 +1275,6 @@ paths:
   /collections/{collection_name}/points/vectors/delete:
     post:
       x-fern-examples:
-        - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_vectors(\n    collection_name=\"{collection_name}\",\n    points=[0, 3, 100],\n    vectors=[\"text\", \"image\"],\n)\n"
-              language: python
-        - code-samples:
-            - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .deleteVectorsAsync(\n        \"{collection_name}\", List.of(\"text\", \"image\"), List.of(id(0), id(3), id(10)))\n    .get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteVectors() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.DeleteVectors(context.Background(), &qdrant.DeletePointVectors{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100)),\n\t\tVectors: &qdrant.VectorsSelector{\n\t\t\tNames: []string{\"text\", \"image\"},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.deleteVectors(\"{collection_name}\", {\n  points: [0, 3, 10],\n  vectors: [\"text\", \"image\"],\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::{DeletePointVectorsBuilder, PointsIdsList, VectorsSelector};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_vectors(\n        DeletePointVectorsBuilder::new(\"{collection_name}\")\n            .points_selector(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            })\n            .vectors(VectorsSelector {\n                names: vec![\"text\".into(), \"image\".into()],\n            })\n            .wait(true),\n    )\n    .await?;\n"
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -1302,8 +1287,23 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_vectors(\n    collection_name=\"{collection_name}\",\n    points=[0, 3, 100],\n    vectors=[\"text\", \"image\"],\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::{DeletePointVectorsBuilder, PointsIdsList, VectorsSelector};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_vectors(\n        DeletePointVectorsBuilder::new(\"{collection_name}\")\n            .points_selector(PointsIdsList {\n                ids: vec![0.into(), 3.into(), 10.into()],\n            })\n            .vectors(VectorsSelector {\n                names: vec![\"text\".into(), \"image\".into()],\n            })\n            .wait(true),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient\n    .deleteVectorsAsync(\n        \"{collection_name}\", List.of(\"text\", \"image\"), List.of(id(0), id(3), id(10)))\n    .get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteVectors() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.DeleteVectors(context.Background(), &qdrant.DeletePointVectors{\n\t\tCollectionName: \"{collection_name}\",\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100)),\n\t\tVectors: &qdrant.VectorsSelector{\n\t\t\tNames: []string{\"text\", \"image\"},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "# Delete vectors by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/vectors/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"points\": [\n    0,\n    3,\n    10\n  ],\n  \"vectors\": [\n    \"text\",\n    \"image\"\n  ]\n}'\n\n# Delete vectors by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/vectors/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"vectors\": [\n    \"text\",\n    \"image\"\n  ]\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.deleteVectors(\"{collection_name}\", {\n  points: [0, 3, 10],\n  vectors: [\"text\", \"image\"],\n});\n"
+              language: typescript
       description: Deletes specified vectors from points. All other unspecified vectors will stay intact.
       summary: Delete vectors
       tags:
@@ -1311,6 +1311,9 @@ paths:
   /collections/{collection_name}/shards:
     put:
       x-fern-examples:
+        - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreateShardKeyAsync(\n    \"{collection_name}\",\n    new CreateShardKey { ShardKey = new ShardKey { Keyword = \"{shard_key}\", } }\n);\n"
+              language: csharp
         - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
@@ -1323,23 +1326,20 @@ paths:
 '
               language: python
         - code-samples:
+            - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::{CreateShardKeyBuilder, CreateShardKeyRequestBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_shard_key(\n        CreateShardKeyRequestBuilder::new(\"{collection_name}\").request(\n            CreateShardKeyBuilder::default()\n                .shard_key(Key::Keyword(\"{shard_key}\".to_string())),\n        ),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
             - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.CreateShardKey;\nimport io.qdrant.client.grpc.Collections.CreateShardKeyRequest;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createShardKeyAsync(CreateShardKeyRequest.newBuilder()\n                .setCollectionName(\"{collection_name}\")\n                .setRequest(CreateShardKey.newBuilder()\n                                .setShardKey(shardKey(\"{shard_key}\"))\n                                .build())\n                .build()).get();\n"
               language: java
         - code-samples:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createShardKey() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.CreateShardKey(context.Background(), \"{collection_name}\", &qdrant.CreateShardKey{\n\t\tShardKey: qdrant.NewShardKey(\"{shard_key}\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n});\n\nclient.createShardKey(\"{collection_name}\", {\n    shard_key: \"{shard_key}\"\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::{CreateShardKeyBuilder, CreateShardKeyRequestBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .create_shard_key(\n        CreateShardKeyRequestBuilder::new(\"{collection_name}\").request(\n            CreateShardKeyBuilder::default()\n                .shard_key(Key::Keyword(\"{shard_key}\".to_string())),\n        ),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CreateShardKeyAsync(\n    \"{collection_name}\",\n    new CreateShardKey { ShardKey = new ShardKey { Keyword = \"{shard_key}\", } }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/shards' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"shard_key\": \"{shard_key}\"\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n});\n\nclient.createShardKey(\"{collection_name}\", {\n    shard_key: \"{shard_key}\"\n});\n"
+              language: typescript
       description: Creates one or more shard keys for a specified collection.
       summary: Create a shard key
       tags:
@@ -1347,6 +1347,9 @@ paths:
   /collections/{collection_name}/shards/delete:
     post:
       x-fern-examples:
+        - code-samples:
+            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DeleteShardKeyAsync(\n    \"{collection_name}\",\n    new DeleteShardKey { ShardKey = new ShardKey { Keyword = \"shard_key\", } }\n);\n"
+              language: csharp
         - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
@@ -1359,23 +1362,20 @@ paths:
 '
               language: python
         - code-samples:
+            - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::DeleteShardKeyRequestBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_shard_key(\n        DeleteShardKeyRequestBuilder::new(\"{collection_name}\")\n            .key(Key::Keyword(\"{shard_key}\".to_string())),\n    )\n    .await?;\n"
+              language: rust
+        - code-samples:
             - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Collections.DeleteShardKey;\nimport io.qdrant.client.grpc.Collections.DeleteShardKeyRequest;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteShardKeyAsync(DeleteShardKeyRequest.newBuilder()\n                .setCollectionName(\"{collection_name}\")\n                .setRequest(DeleteShardKey.newBuilder()\n                                .setShardKey(shardKey(\"{shard_key}\"))\n                                .build())\n                .build()).get();\n"
               language: java
         - code-samples:
             - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteShardKey() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteShardKey(context.Background(), \"{collection_name}\", &qdrant.DeleteShardKey{\n\t\tShardKey: qdrant.NewShardKey(\"{shard_key}\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
               language: go
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n});\n\nclient.deleteShardKey(\"{collection_name}\", {\n    shard_key: \"{shard_key}\"\n});\n"
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::DeleteShardKeyRequestBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_shard_key(\n        DeleteShardKeyRequestBuilder::new(\"{collection_name}\")\n            .key(Key::Keyword(\"{shard_key}\".to_string())),\n    )\n    .await?;\n"
-              language: rust
-        - code-samples:
-            - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.DeleteShardKeyAsync(\n    \"{collection_name}\",\n    new DeleteShardKey { ShardKey = new ShardKey { Keyword = \"shard_key\", } }\n);\n"
-              language: csharp
-        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/shards/delete' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"shard_key\": \"{shard_key}\"\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n});\n\nclient.deleteShardKey(\"{collection_name}\", {\n    shard_key: \"{shard_key}\"\n});\n"
+              language: typescript
       description: Deletes one or more shard keys for a specified collection.
       summary: Delete a shard key
       tags:
@@ -1383,45 +1383,6 @@ paths:
   /collections/{collection_name}/snapshots:
     get:
       x-fern-examples:
-        - code-samples:
-            - code: 'from qdrant_client import QdrantClient
-
-
-                client = QdrantClient(url="http://localhost:6333")
-
-
-                client.list_snapshots(collection_name="{collection_name}")
-
-'
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listSnapshotAsync(\"{collection_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListSnapshots(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshots: \", snapshots)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.listSnapshots("{collection_name}");
-
-'
-              language: typescript
-        - code-samples:
-            - code: 'use qdrant_client::Qdrant;
-
-
-                let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-
-                client.list_snapshots("{collection_name}").await?;
-
-'
-              language: rust
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -1434,42 +1395,16 @@ paths:
 '
               language: csharp
         - code-samples:
-            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/snapshots' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
-      description: Retrieves a list of all snapshots for a specified collection.
-      summary: List all snapshots (collection)
-      tags:
-        - Snapshots
-    post:
-      x-fern-examples:
-        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
                 client = QdrantClient(url="http://localhost:6333")
 
 
-                client.create_snapshot(collection_name="{collection_name}")
+                client.list_snapshots(collection_name="{collection_name}")
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createSnapshotAsync(\"{collection_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateSnapshot(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshot created: \", snapshot.Name)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.createSnapshot("{collection_name}");
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -1477,10 +1412,36 @@ paths:
                 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
 
-                client.create_snapshot("{collection_name}").await?;
+                client.list_snapshots("{collection_name}").await?;
 
 '
               language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listSnapshotAsync(\"{collection_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListSnapshots(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshots: \", snapshots)\n}\n"
+              language: go
+        - code-samples:
+            - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/snapshots' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.listSnapshots("{collection_name}");
+
+'
+              language: typescript
+      description: Retrieves a list of all snapshots for a specified collection.
+      summary: List all snapshots (collection)
+      tags:
+        - Snapshots
+    post:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -1493,8 +1454,47 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: 'from qdrant_client import QdrantClient
+
+
+                client = QdrantClient(url="http://localhost:6333")
+
+
+                client.create_snapshot(collection_name="{collection_name}")
+
+'
+              language: python
+        - code-samples:
+            - code: 'use qdrant_client::Qdrant;
+
+
+                let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+                client.create_snapshot("{collection_name}").await?;
+
+'
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createSnapshotAsync(\"{collection_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateSnapshot(context.Background(), \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshot created: \", snapshot.Name)\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/snapshots' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.createSnapshot("{collection_name}");
+
+'
+              language: typescript
       description: Creates a new snapshot for a specified collection.
       summary: Create a snapshot (collection)
       tags:
@@ -1506,11 +1506,11 @@ paths:
             - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.recover_snapshot(\n    \"{collection_name}\",\n    \"http://example.com/path/to/snapshot.shapshot\",\n)\n"
               language: python
         - code-samples:
-            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recoverSnapshot(\"{collection_name}\", {\n  location: \"http://example.com/path/to/snapshot.shapshot\",\n});\n"
-              language: typescript
-        - code-samples:
             - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/snapshots/recover' \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json' \\\n  --data-raw '{\n  \"location\": \"http://example.com/path/to/snapshot.shapshot\"\n}'"
               language: curl
+        - code-samples:
+            - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\nclient.recoverSnapshot(\"{collection_name}\", {\n  location: \"http://example.com/path/to/snapshot.shapshot\",\n});\n"
+              language: typescript
       description: Recovers local collection data from a snapshot. This will overwrite any collection data stored on the node. If the collection does not exist, it will be created.
       summary: Recover from a snapshot (collection)
       tags:
@@ -1529,29 +1529,6 @@ paths:
     delete:
       x-fern-examples:
         - code-samples:
-            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_snapshot(\n    collection_name=\"{collection_name}\", snapshot_name=\"{snapshot_name}\"\n)\n"
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteSnapshotAsync(\"{collection_name}\", \"{snapshot_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteSnapshot(context.Background(), \"{collection_name}\", \"{snapshot_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.deleteSnapshot("{collection_name}", "{snapshot_name}");
-
-'
-              language: typescript
-        - code-samples:
-            - code: "use qdrant_client::qdrant::DeleteSnapshotRequestBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_snapshot(DeleteSnapshotRequestBuilder::new(\n        \"{collection_name}\",\n        \"{snapshot_name}\",\n    ))\n    .await?;\n"
-              language: rust
-        - code-samples:
             - code: 'using Qdrant.Client;
 
 
@@ -1563,8 +1540,31 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"http://localhost:6333\")\n\nclient.delete_snapshot(\n    collection_name=\"{collection_name}\", snapshot_name=\"{snapshot_name}\"\n)\n"
+              language: python
+        - code-samples:
+            - code: "use qdrant_client::qdrant::DeleteSnapshotRequestBuilder;\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n    .delete_snapshot(DeleteSnapshotRequestBuilder::new(\n        \"{collection_name}\",\n        \"{snapshot_name}\",\n    ))\n    .await?;\n"
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteSnapshotAsync(\"{collection_name}\", \"{snapshot_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteSnapshot(context.Background(), \"{collection_name}\", \"{snapshot_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name/snapshots/snapshot_name' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.deleteSnapshot("{collection_name}", "{snapshot_name}");
+
+'
+              language: typescript
       description: Deletes the specified snapshot for a collection.
       summary: Delete a snapshot (collection)
       tags:
@@ -1578,6 +1578,17 @@ paths:
     get:
       x-fern-examples:
         - code-samples:
+            - code: 'using Qdrant.Client;
+
+
+                var client = new QdrantClient("localhost", 6334);
+
+
+                await client.ListFullSnapshotsAsync();
+
+'
+              language: csharp
+        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
@@ -1588,23 +1599,6 @@ paths:
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listFullSnapshotAsync().get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listFullSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListFullSnapshots(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Full snapshots: \", snapshots)\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.listFullSnapshots();
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -1617,42 +1611,14 @@ paths:
 '
               language: rust
         - code-samples:
-            - code: 'using Qdrant.Client;
-
-
-                var client = new QdrantClient("localhost", 6334);
-
-
-                await client.ListFullSnapshotsAsync();
-
-'
-              language: csharp
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.listFullSnapshotAsync().get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc listFullSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListFullSnapshots(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Full snapshots: \", snapshots)\n}\n"
+              language: go
         - code-samples:
             - code: "curl  -X GET \\\n  'http://localhost:6333/snapshots' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
-      description: Returns a list of all snapshots for the entire storage.
-      summary: List all snapshots (storage)
-      tags:
-        - Snapshots
-    post:
-      x-fern-examples:
-        - code-samples:
-            - code: 'from qdrant_client import QdrantClient
-
-
-                client = QdrantClient(url="http://localhost:6333")
-
-
-                client.create_full_snapshot()
-
-'
-              language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createFullSnapshotAsync().get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateFullSnapshot(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshot created: \", snapshot.Name)\n}\n"
-              language: go
         - code-samples:
             - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
 
@@ -1660,21 +1626,16 @@ paths:
                 const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 
-                client.createFullSnapshot();
+                client.listFullSnapshots();
 
 '
               language: typescript
-        - code-samples:
-            - code: 'use qdrant_client::Qdrant;
-
-
-                let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-
-                client.create_full_snapshot().await?;
-
-'
-              language: rust
+      description: Returns a list of all snapshots for the entire storage.
+      summary: List all snapshots (storage)
+      tags:
+        - Snapshots
+    post:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -1687,43 +1648,16 @@ paths:
 '
               language: csharp
         - code-samples:
-            - code: "curl  -X POST \\\n  'http://localhost:6333/snapshots' \\\n  --header 'api-key: <api-key-value>'"
-              language: curl
-      description: Creates a new snapshot of the entire storage.
-      summary: Create a snapshot (storage)
-      tags:
-        - Snapshots
-  /snapshots/{snapshot_name}:
-    delete:
-      x-fern-examples:
-        - code-samples:
             - code: 'from qdrant_client import QdrantClient
 
 
                 client = QdrantClient(url="http://localhost:6333")
 
 
-                client.delete_full_snapshot(snapshot_name="{snapshot_name}")
+                client.create_full_snapshot()
 
 '
               language: python
-        - code-samples:
-            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteFullSnapshotAsync(\"{snapshot_name}\").get();\n"
-              language: java
-        - code-samples:
-            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteFullSnapshot(context.Background(), \"{snapshot_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
-              language: go
-        - code-samples:
-            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
-
-
-                const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-
-                client.deleteFullSnapshot("{snapshot_name}");
-
-'
-              language: typescript
         - code-samples:
             - code: 'use qdrant_client::Qdrant;
 
@@ -1731,10 +1665,37 @@ paths:
                 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
 
-                client.delete_full_snapshot("{snapshot_name}").await?;
+                client.create_full_snapshot().await?;
 
 '
               language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.createFullSnapshotAsync().get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc createFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateFullSnapshot(context.Background())\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshot created: \", snapshot.Name)\n}\n"
+              language: go
+        - code-samples:
+            - code: "curl  -X POST \\\n  'http://localhost:6333/snapshots' \\\n  --header 'api-key: <api-key-value>'"
+              language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.createFullSnapshot();
+
+'
+              language: typescript
+      description: Creates a new snapshot of the entire storage.
+      summary: Create a snapshot (storage)
+      tags:
+        - Snapshots
+  /snapshots/{snapshot_name}:
+    delete:
+      x-fern-examples:
         - code-samples:
             - code: 'using Qdrant.Client;
 
@@ -1747,8 +1708,47 @@ paths:
 '
               language: csharp
         - code-samples:
+            - code: 'from qdrant_client import QdrantClient
+
+
+                client = QdrantClient(url="http://localhost:6333")
+
+
+                client.delete_full_snapshot(snapshot_name="{snapshot_name}")
+
+'
+              language: python
+        - code-samples:
+            - code: 'use qdrant_client::Qdrant;
+
+
+                let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+                client.delete_full_snapshot("{snapshot_name}").await?;
+
+'
+              language: rust
+        - code-samples:
+            - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\nclient.deleteFullSnapshotAsync(\"{snapshot_name}\").get();\n"
+              language: java
+        - code-samples:
+            - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\n)\n\nfunc deleteFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteFullSnapshot(context.Background(), \"{snapshot_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+              language: go
+        - code-samples:
             - code: "curl  -X DELETE \\\n  'http://localhost:6333/snapshots/snapshot_name' \\\n  --header 'api-key: <api-key-value>'"
               language: curl
+        - code-samples:
+            - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+                const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+                client.deleteFullSnapshot("{snapshot_name}");
+
+'
+              language: typescript
       description: Deletes the specified snapshot of the entire storage.
       summary: Delete a snapshot (storage)
       tags:

--- a/fern/apis/v1.18.x/generators.yml
+++ b/fern/apis/v1.18.x/generators.yml
@@ -1,0 +1,4 @@
+api:
+  specs:
+    - openapi: ./openapi.json
+      overrides: ./openapi-overrides.yml

--- a/fern/apis/v1.18.x/openapi-overrides.yml
+++ b/fern/apis/v1.18.x/openapi-overrides.yml
@@ -1,0 +1,3946 @@
+components:
+  securitySchemes:
+    BearerAuth:
+      scheme: bearer
+      type: http
+paths:
+  /:
+    get:
+      description: Returns details about the running Qdrant instance.
+      summary: Retrieve instance details
+      tags:
+      - Service
+  /aliases:
+    get:
+      description: Retrieves a list of all existing aliases.
+      summary: List all aliases
+      tags:
+      - Aliases
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ListAliasesAsync();
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.get_aliases()
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.list_aliases().await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.listAliasesAsync().get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc listAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\taliases, err := client.ListAliases(context.Background())\n\
+            \tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Aliases: \", aliases)\n\
+            }\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/aliases' \\\n  --header\
+            \ 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.getAliases();
+
+            '
+          language: typescript
+  /cluster:
+    get:
+      description: Returns information about the cluster's current state and composition.
+      summary: Check cluster status
+      tags:
+      - Distributed
+  /cluster/peer/{peer_id}:
+    delete:
+      description: Attempts to remove the node from the cluster. This endpoint returns
+        an error if the node (peer) has shards on it.
+      summary: Remove peer from cluster
+      tags:
+      - Distributed
+  /cluster/recover:
+    post:
+      description: Attempts to restore or synchronize the node's current state with
+        that of its peers.
+      summary: Recover cluster state
+      tags:
+      - Distributed
+  /collections:
+    get:
+      description: Returns a list of all existing collections.
+      summary: List all collections
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ListCollectionsAsync();
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.get_collections()
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.list_collections().await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.listCollectionsAsync().get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc listCollections() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tcollections, err := client.ListCollections(context.Background())\n\
+            \tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Collections: \"\
+            , collections)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/collections' \\\n  --header\
+            \ 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.getCollections();
+
+            '
+          language: typescript
+  /collections/aliases:
+    post:
+      description: Updates aliases for the specified collections.
+      summary: Update collection aliases
+      tags:
+      - Aliases
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.CreateAliasAsync(aliasName: "production_collection", collectionName:
+            "example_collection");
+
+
+            await client.DeleteAliasAsync("production_collection");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.update_collection_aliases(\n    change_aliases_operations=[\n\
+            \        models.CreateAliasOperation(\n            create_alias=models.CreateAlias(\n\
+            \                collection_name=\"example_collection\", alias_name=\"\
+            production_collection\"\n            )\n        )\n    ]\n)\n\nclient.update_collection_aliases(\n\
+            \    change_aliases_operations=[\n        models.DeleteAliasOperation(\n\
+            \            delete_alias=models.DeleteAlias(alias_name=\"production_collection\"\
+            )\n        ),\n    ]\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{CreateAliasBuilder, DeleteAlias};\nuse\
+            \ qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .create_alias(CreateAliasBuilder::new(\n  \
+            \      \"example_collection\",\n        \"production_collection\",\n \
+            \   ))\n    .await?;\n\nclient\n    .delete_alias(DeleteAlias {\n    \
+            \    alias_name: \"production_collection\".to_string(),\n    })\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport\
+            \ io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.DeleteShardKey;\nimport io.qdrant.client.grpc.Collections.DeleteShardKeyRequest;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createAliasAsync(\"production_collection\"\
+            , \"example_collection\").get();\n\nclient.deleteAliasAsync(\"production_collection\"\
+            ).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc updateAlias() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.CreateAlias(context.Background(),\
+            \ \"production_collection\", \"example_collection\")\n\tif err != nil\
+            \ {\n\t\tpanic(err)\n\t}\n\n\terr = client.DeleteAlias(context.Background(),\
+            \ \"production_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\
+            \n\terr = client.RenameAlias(context.Background(), \"production_collection\"\
+            , \"legacy_collection\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Create an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n   \
+            \   \"create_alias\": {\n        \"collection_name\": \"{collection_name}\"\
+            ,\n        \"alias_name\": \"{alias_name}\"\n      }\n    }\n  ]\n}'\n\
+            \n# Delete an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n   \
+            \   \"delete_alias\": {\n        \"alias_name\": \"{alias_name}\"\n  \
+            \    }\n    }\n  ]\n}'\n\n# Rename an alias\ncurl  -X POST \\\n  'http://localhost:6333/collections/aliases'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"actions\": [\n    {\n   \
+            \   \"rename_alias\": {\n        \"old_alias_name\": \"{old_alias_name}\"\
+            ,\n        \"new_alias_name\": \"{new_alias_name}\"\n      }\n    }\n\
+            \  ]\n}'\n"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.updateCollectionAliases({\n  actions: [\n    {\n      create_alias:\
+            \ {\n        collection_name: \"example_collection\",\n        alias_name:\
+            \ \"production_collection\",\n      },\n    },\n  ],\n});\n\nclient.updateCollectionAliases({\n\
+            \  actions: [\n    {\n      delete_alias: {\n        alias_name: \"production_collection\"\
+            ,\n      },\n    },\n  ],\n});\n"
+          language: typescript
+  /collections/{collection_name}:
+    delete:
+      description: Drops the specified collection and all associated data in it.
+      summary: Delete a collection
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeleteCollectionAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.delete_collection(collection_name="{collection_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.delete_collection("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.deleteCollectionAsync(\"\
+            {collection_name}\").get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.DeleteCollection(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from ''@qdrant/qdrant-js'';
+
+
+            const client = new QdrantClient({url: ''http://127.0.0.1:6333''});
+
+
+            client.deleteCollection("{collection_name}");
+
+            '
+          language: typescript
+    get:
+      description: Retrieves parameters from the specified collection.
+      summary: Get collection details
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.GetCollectionInfoAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.get_collection("{collection_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.collection_info("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.getCollectionInfoAsync(\"\
+            {collection_name}\").get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc getCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tinfo, err := client.GetCollectionInfo(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Collection info: \", info)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.getCollection("{collection_name}");
+
+            '
+          language: typescript
+    patch:
+      description: Updates the parameters of the specified collection.
+      summary: Update collection parameters
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateCollectionAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  optimizersConfig: new OptimizersConfigDiff\
+            \ { IndexingThreshold = 10000 }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.update_collection(\n    collection_name=\"\
+            {collection_name}\",\n    optimizer_config=models.OptimizersConfigDiff(indexing_threshold=10000),\n\
+            )\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{OptimizersConfigDiffBuilder, UpdateCollectionBuilder};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .update_collection(\n        UpdateCollectionBuilder::new(\"\
+            {collection_name}\").optimizers_config(\n            OptimizersConfigDiffBuilder::default().indexing_threshold(10_000),\n\
+            \        ),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport\
+            \ io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.OptimizersConfigDiff;\nimport\
+            \ io.qdrant.client.grpc.Collections.UpdateCollection;\n\nQdrantClient\
+            \ client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.updateCollectionAsync(\n\
+            \    UpdateCollection.newBuilder()\n        .setCollectionName(\"{collection_name}\"\
+            )\n        .setOptimizersConfig(\n            OptimizersConfigDiff.newBuilder().setIndexingThreshold(10000).build())\n\
+            \        .build());\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc updateCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tthreshold := uint64(10000)\n\terr = client.UpdateCollection(context.Background(),\
+            \ &qdrant.UpdateCollection{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tOptimizersConfig: &qdrant.OptimizersConfigDiff{\n\t\t\tIndexingThreshold:\
+            \ &threshold,\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\
+            }\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X PATCH \\\n  'http://localhost:6333/collections/collection_name'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"optimizers_config\": {\n\
+            \    \"indexing_threshold\": 10000\n  }\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.updateCollection(\"{collection_name}\", {\n  optimizers_config:\
+            \ {\n    indexing_threshold: 10000,\n  },\n});\n"
+          language: typescript
+    put:
+      description: Creates a new collection with the given parameters.
+      summary: Create a collection
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.CreateCollectionAsync(\n\
+            \tcollectionName: \"{collection_name}\",\n\tvectorsConfig: new VectorParams\
+            \ { Size = 100, Distance = Distance.Cosine }\n);\n\n// Or with sparse\
+            \ vectors\n\nawait client.CreateCollectionAsync(\n\tcollectionName: \"\
+            {collection_name}\",\n\tsparseVectorsConfig: (\"splade-model-name\", new\
+            \ SparseVectorParams{\n        Index = new SparseIndexConfig {\n     \
+            \       OnDisk = false,\n        }\n    })\n);"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.create_collection(\n    collection_name=\"\
+            {collection_name}\",\n    vectors_config=models.VectorParams(size=100,\
+            \ distance=models.Distance.COSINE),\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .create_collection(\n        CreateCollectionBuilder::new(\"\
+            {collection_name}\")\n            .vectors_config(VectorParamsBuilder::new(100,\
+            \ Distance::Cosine)),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.Distance;\nimport io.qdrant.client.grpc.Collections.VectorParams;\n\
+            \nQdrantClient client = new QdrantClient(\n    QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createCollectionAsync(\"\
+            {collection_name}\",\n        VectorParams.newBuilder().setDistance(Distance.Cosine).setSize(100).build()).get();\n\
+            \n// Or with sparse vectors\n\nclient.createCollectionAsync(\n    CreateCollection.newBuilder()\n\
+            \        .setCollectionName(\"{collection_name}\")\n        .setSparseVectorsConfig(\n\
+            \            Collections.SparseVectorConfig.newBuilder().putMap(\n   \
+            \             \"splade-model-name\",\n                Collections.SparseVectorParams.newBuilder()\n\
+            \                    .setIndex(\n                        Collections.SparseIndexConfig\n\
+            \                            .newBuilder()\n                         \
+            \   .setOnDisk(false)\n                            .build()\n        \
+            \            ).build()\n            ).build()\n        ).build()\n).get();"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc createCollection() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.CreateCollection(context.Background(),\
+            \ &qdrant.CreateCollection{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tVectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{\n\t\
+            \t\tSize:     100,\n\t\t\tDistance: qdrant.Distance_Cosine,\n\t\t}),\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Create a collection with default dense vector\ncurl  -X PUT \\\n\
+            \  'http://localhost:6333/collections/collection_name' \\\n  --header\
+            \ 'api-key: <api-key-value>' \\\n  --header 'Content-Type: application/json'\
+            \ \\\n  --data-raw '{\n  \"vectors\": {\n    \"size\": 384,\n    \"distance\"\
+            : \"Cosine\"\n  }\n}'\n\n# Create a collection with named dense and sparse\
+            \ vectors\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"vectors\": {\n    \"dense-vector-name\"\
+            : {\n      \"size\": 1536,\n      \"distance\": \"Cosine\"\n    }\n  },\n\
+            \  \"sparse_vectors\": {\n    \"sparse-vector-name\": {\n      \"index\"\
+            : {\n        \"on_disk\": true\n      }\n    }\n  }\n}'\n"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.createCollection(\"{collection_name}\", {\n  vectors: { size: 100,\
+            \ distance: \"Cosine\" },\n});\n\n// or with sparse vectors\n\nclient.createCollection(\"\
+            {collection_name}\", {\n  vectors: { size: 100, distance: \"Cosine\" },\n\
+            \  sparse_vectors: {\n    \"splade-model-name\": {\n      index: {\n \
+            \       on_disk: false\n      }\n    }\n  }\n});"
+          language: typescript
+  /collections/{collection_name}/aliases:
+    get:
+      description: Retrieves a list of all aliases for the specified collection.
+      summary: List collection aliases
+      tags:
+      - Aliases
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ListCollectionAliasesAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.get_collection_aliases("{collection_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.list_collection_aliases("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.listCollectionAliasesAsync(\"\
+            {collection_name}\").get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc listCollectionAliases() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\taliases, err := client.ListCollectionAliases(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Collection aliases: \", aliases)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/aliases'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.getCollectionAliases("{collection_name}");
+
+            '
+          language: typescript
+  /collections/{collection_name}/cluster:
+    get:
+      description: Retrieves cluster details for a specified collection.
+      summary: Retrieve cluster details
+      tags:
+      - Distributed
+    post:
+      description: Updates the cluster configuration for a specified collection.
+      summary: Update cluster setup
+      tags:
+      - Distributed
+  /collections/{collection_name}/exists:
+    get:
+      description: Checks whether the specified collection exists.
+      summary: Check collection existence
+      tags:
+      - Collections
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.CollectionExistsAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.collection_exists(collection_name="{collection_name}")'
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.collection_exists("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: 'import static io.qdrant.client.ConditionFactory.matchKeyword;
+
+
+            import io.qdrant.client.QdrantClient;
+
+            import io.qdrant.client.QdrantGrpcClient;
+
+
+            QdrantClient client = new QdrantClient(QdrantGrpcClient.newBuilder("localhost",
+            6334, false).build());
+
+
+            client.collectionExistsAsync("{collection_name}").get();
+
+            '
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc collectionExists() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\texists, err := client.CollectionExists(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Collection exists: \", exists)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/exists'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.collectionExists("{collection_name}");
+
+            '
+          language: typescript
+  /collections/{collection_name}/facet:
+    post:
+      description: Retrieves facets for the specified payload field.
+      summary: Payload field facets
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.FacetAsync(\n\t\"\
+            {collection_name}\",\n\tfilter: MatchKeyword(\"color\", \"red\"),\n\t\
+            key: \"my-payload-key\",\n\tlimit: 10\n);"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.facet(\n    collection_name=\"{collection_name}\"\
+            ,\n    key=\"my-payload-key\",\n    facet_filter=models.Filter(must=[models.Match(\"\
+            color\", \"red\")]),\n    limit=10,\n)\n\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, FacetCountsBuilder, Filter};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .facet(\n         FacetCountsBuilder::new(\"\
+            {collection_name}\", \"my-payload-key\")\n             .limit(10)\n  \
+            \           .filter(Filter::must(vec![Condition::matches(\n          \
+            \       \"color\",\n                 \"red\".to_string(),\n          \
+            \   )])),\n     )\n     .await?;"
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport static io.qdrant.client.ConditionFactory.matchKeyword;\nimport\
+            \ io.qdrant.client.grpc.Points;\nimport io.qdrant.client.grpc.Filter;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .facetAsync(\n    \
+            \    Points.FacetCounts.newBuilder()\n            .setCollectionName(collection_name)\n\
+            \            .setKey(\"my-payload-key\")\n            .setFilter(\n  \
+            \              Filter.newBuilder()\n                    .addMust(matchKeyword(\"\
+            color\", \"red\"))\n                    .build())\n            .build())\n\
+            \        .get();"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc facet() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tlimit := uint64(10)\n\tresults, err := client.Facet(context.Background(),\
+            \ &qdrant.FacetCounts{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tKey:            \"my-payload-key\",\n\t\tLimit:          &limit,\n\t\
+            \tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\t\
+            qdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t},\n\t})\n\tif err\
+            \ != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", results)\n\
+            }\n"
+          language: go
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.facet(\"{collection_name}\", {\n    filter: {\n        must: [\n\
+            \            {\n                key: \"color\",\n                match:\
+            \ {\n                    value: \"red\",\n                },\n       \
+            \     },\n        ],\n    },\n    key: \"my-payload-key\",\n    limit:\
+            \ 10,\n});\n"
+          language: typescript
+  /collections/{collection_name}/index:
+    put:
+      description: Creates a payload index for a field in the specified collection.
+      summary: Create payload index
+      tags:
+      - Indexes
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\"\
+            , 6334);\n\nawait client.CreatePayloadIndexAsync(\n  collectionName: \"\
+            {collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.create_payload_index(\n    collection_name=\"\
+            {collection_name}\",\n    field_name=\"name_of_the_field_to_index\",\n\
+            \    field_schema=\"keyword\",\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .create_field_index(\n        CreateFieldIndexCollectionBuilder::new(\n\
+            \            \"{collection_name}\",\n            \"{field_name}\",\n \
+            \           FieldType::Keyword,\n        ),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.PayloadSchemaType;\n\nQdrantClient\
+            \ client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createPayloadIndexAsync(\n\
+            \                \"{collection_name}\",\n                \"{field_name}\"\
+            ,\n                PayloadSchemaType.Keyword,\n                null,\n\
+            \                true,\n                null,\n                null);\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc createFieldIndex() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.CreateFieldIndex(context.Background(),\
+            \ &qdrant.CreateFieldIndexCollection{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tFieldName:      \"name_of_the_field_to_index\",\n\t\tFieldType:\
+            \      qdrant.FieldType_FieldTypeKeyword.Enum(),\n\t})\n\tif err != nil\
+            \ {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/index'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"field_name\": \"field_name\"\
+            ,\n  \"field_schema\": \"keyword\"\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.createPayloadIndex(\"{collection_name}\", {\n  field_name: \"{field_name}\"\
+            ,\n  field_schema: \"keyword\",\n});\n"
+          language: typescript
+  /collections/{collection_name}/index/{field_name}:
+    delete:
+      description: Deletes a payload index for a field in the specified collection.
+      summary: Delete payload index
+      tags:
+      - Indexes
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\"\
+            , 6334);\n\nawait client.DeletePayloadIndexAsync(\n  collectionName: \"\
+            {collection_name}\",\n  fieldName: \"name_of_the_field_to_index\"\n);\n"
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.delete_payload_index("{collection_name}", "{field_name}");
+
+            '
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::DeleteFieldIndexCollectionBuilder;\nuse\
+            \ qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .delete_field_index(DeleteFieldIndexCollectionBuilder::new(\n\
+            \        \"{collection_name}\",\n        \"{field_name}\",\n    ))\n \
+            \   .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.deletePayloadIndexAsync(\"\
+            {collection_name}\", \"{field_name}\", true, null, null).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteFieldIndex() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.DeleteFieldIndex(context.Background(),\
+            \ &qdrant.DeleteFieldIndexCollection{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tFieldName:      \"{field_name}\",\n\t})\n\tif err != nil {\n\t\t\
+            panic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name/index/field_name'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.deletePayloadIndex("{collection_name}", "{field_name}");
+
+            '
+          language: typescript
+  /collections/{collection_name}/points:
+    post:
+      description: Retrieves all details from multiple points.
+      summary: Retrieve points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\"\
+            , 6334);\n\nawait client.RetrieveAsync(\n  collectionName: \"{collection_name}\"\
+            ,\n  ids: [0, 30, 100],\n  withPayload: false,\n  withVectors: false\n\
+            );\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.retrieve(\n    collection_name=\"{collection_name}\"\
+            ,\n    ids=[0, 3, 100],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::GetPointsBuilder;\nuse qdrant_client::Qdrant;\n\
+            \nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\
+            \nclient\n    .get_points(GetPointsBuilder::new(\n        \"{collection_name}\"\
+            ,\n        vec![0.into(), 30.into(), 100.into()],\n    ))\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .retrieveAsync(\"{collection_name}\"\
+            , List.of(id(0), id(30), id(100)), false, false, null)\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc getPoints() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tpoints, err := client.Get(context.Background(),\
+            \ &qdrant.GetPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\t\
+            Ids: []*qdrant.PointId{\n\t\t\tqdrant.NewIDNum(0), qdrant.NewID(\"3\"\
+            ), qdrant.NewIDNum(100),\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\
+            \t}\n\tfmt.Println(\"Points: \", points)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"ids\": [\n    0,\n    3,\n\
+            \    100\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.retrieve(\"{collection_name}\", {\n  ids: [0, 3, 100],\n});\n"
+          language: typescript
+    put:
+      description: Performs the insert + update action on specified points. Any point
+        with an existing {id} will be overwritten.
+      summary: Upsert points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.UpsertAsync(\n  collectionName:\
+            \ \"{collection_name}\",\n  points: new List<PointStruct>\n  {\n    new()\n\
+            \    {\n      Id = 1,\n      Vectors = new[] { 0.9f, 0.1f, 0.1f },\n \
+            \     Payload = { [\"city\"] = \"red\" }\n    },\n    new()\n    {\n \
+            \     Id = 2,\n      Vectors = new[] { 0.1f, 0.9f, 0.1f },\n      Payload\
+            \ = { [\"city\"] = \"green\" }\n    },\n    new()\n    {\n      Id = 3,\n\
+            \      Vectors = new[] { 0.1f, 0.1f, 0.9f },\n      Payload = { [\"city\"\
+            ] = \"blue\" }\n    }\n  }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.upsert(\n    collection_name=\"{collection_name}\"\
+            ,\n    points=[\n        models.PointStruct(\n            id=1,\n    \
+            \        payload={\n                \"color\": \"red\",\n            },\n\
+            \            vector=[0.9, 0.1, 0.1],\n        ),\n        models.PointStruct(\n\
+            \            id=2,\n            payload={\n                \"color\":\
+            \ \"green\",\n            },\n            vector=[0.1, 0.9, 0.1],\n  \
+            \      ),\n        models.PointStruct(\n            id=3,\n          \
+            \  payload={\n                \"color\": \"blue\",\n            },\n \
+            \           vector=[0.1, 0.1, 0.9],\n        ),\n    ],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};\n\
+            use qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client\
+            \ = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n\
+            \    .upsert_points(\n        UpsertPointsBuilder::new(\n            \"\
+            {collection_name}\",\n            vec![\n                PointStruct::new(\n\
+            \                    1,\n                    vec![0.9, 0.1, 0.1],\n  \
+            \                  Payload::try_from(json!(\n                        {\"\
+            color\": \"red\"}\n                    ))\n                    .unwrap(),\n\
+            \                ),\n                PointStruct::new(\n             \
+            \       2,\n                    vec![0.1, 0.9, 0.1],\n               \
+            \     Payload::try_from(json!(\n                        {\"color\": \"\
+            green\"}\n                    ))\n                    .unwrap(),\n   \
+            \             ),\n                PointStruct::new(\n                \
+            \    3,\n                    vec![0.1, 0.1, 0.9],\n                  \
+            \  Payload::try_from(json!(\n                        {\"color\": \"blue\"\
+            }\n                    ))\n                    .unwrap(),\n          \
+            \      ),\n            ],\n        )\n        .wait(true),\n    )\n  \
+            \  .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static\
+            \ io.qdrant.client.VectorFactory.vector;\nimport static io.qdrant.client.VectorsFactory.namedVectors;\n\
+            \nimport java.util.List;\nimport java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.PointStruct;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .upsertAsync(\n   \
+            \     \"{collection_name}\",\n        List.of(\n            PointStruct.newBuilder()\n\
+            \                .setId(id(1))\n                .setVectors(\n       \
+            \             namedVectors(\n                        Map.of(\n       \
+            \                     \"image\",\n                            vector(List.of(0.9f,\
+            \ 0.1f, 0.1f, 0.2f)),\n                            \"text\",\n       \
+            \                     vector(List.of(0.4f, 0.7f, 0.1f, 0.8f, 0.1f, 0.1f,\
+            \ 0.9f, 0.2f)))))\n                .build(),\n            PointStruct.newBuilder()\n\
+            \                .setId(id(2))\n                .setVectors(\n       \
+            \             namedVectors(\n                        Map.of(\n       \
+            \                     \"image\",\n                            List.of(0.2f,\
+            \ 0.1f, 0.3f, 0.9f),\n                            \"text\",\n        \
+            \                    List.of(0.5f, 0.2f, 0.7f, 0.4f, 0.7f, 0.2f, 0.3f,\
+            \ 0.9f))))\n                .build()))\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc upsert() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresponse, err := client.Upsert(context.Background(),\
+            \ &qdrant.UpsertPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tPoints: []*qdrant.PointStruct{\n\t\t\t{\n\t\t\t\tId:      qdrant.NewIDNum(1),\n\
+            \t\t\t\tVectors: qdrant.NewVectors(0.9, 0.1, 0.1),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\
+            \t\t\t\t\t\"color\": \"red\",\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\t\
+            Id:      qdrant.NewIDNum(2),\n\t\t\t\tVectors: qdrant.NewVectors(0.1,\
+            \ 0.9, 0.1),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\
+            \t\t\t\"color\": \"green\",\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\t\
+            Id:      qdrant.NewIDNum(3),\n\t\t\t\tVectors: qdrant.NewVectors(0.1,\
+            \ 0.1, 0.9),\n\t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\
+            \t\t\t\"color\": \"blue\",\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif\
+            \ err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Upsert status: \"\
+            , response.GetStatus())\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"points\": [\n    {\n    \
+            \  \"id\": \"76874cce-1fb9-4e16-9b0b-f085ac06ed6f\",\n      \"payload\"\
+            : {\n        \"color\": \"red\"\n      },\n      \"vector\": [\n     \
+            \   0.9,\n        0.1,\n        0.1\n      ]\n    },\n    {\n      \"\
+            id\": 1,\n      \"payload\": {\n        \"color\": \"green\"\n      },\n\
+            \      \"vector\": [\n        0.1,\n        0.9,\n        0.1\n      ]\n\
+            \    },\n    {\n      \"id\": 2,\n      \"payload\": {\n        \"color\"\
+            : \"blue\"\n      },\n      \"vector\": [\n        0.1,\n        0.1,\n\
+            \        0.9\n      ]\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.upsert(\"{collection_name}\", {\n  points: [\n    {\n      id:\
+            \ 1,\n      payload: { color: \"red\" },\n      vector: [0.9, 0.1, 0.1],\n\
+            \    },\n    {\n      id: 2,\n      payload: { color: \"green\" },\n \
+            \     vector: [0.1, 0.9, 0.1],\n    },\n    {\n      id: 3,\n      payload:\
+            \ { color: \"blue\" },\n      vector: [0.1, 0.1, 0.9],\n    },\n  ],\n\
+            });\n"
+          language: typescript
+  /collections/{collection_name}/points/batch:
+    post:
+      description: Batch updates points, including their respective vectors and payloads.
+      summary: Batch update points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateBatchAsync(\n\
+            \    \"{collection_name}\",\n    [\n        new()\n        {\n       \
+            \     Upsert = new()\n            {\n                Points =\n      \
+            \          {\n                    new PointStruct { Id = 1, Vectors =\
+            \ new[] { 0.9f, 0.1f, 0.1f } },\n                }\n            }\n  \
+            \      },\n        new()\n        {\n            UpdateVectors = new()\n\
+            \            {\n                Points =\n                {\n        \
+            \            new PointVectors { Id = 1, Vectors = new[] { 0.9f, 0.1f,\
+            \ 0.1f } },\n                }\n            }\n        },\n        new()\n\
+            \        {\n            SetPayload = new()\n            {\n          \
+            \      PointsSelector = new PointsSelector { Points = new PointsIdsList\
+            \ { Ids = { 1 } } },\n                Payload = { [\"test_payload_2\"\
+            ] = 2, [\"test_payload_3\"] = 3 }\n            }\n        }\n    ]\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.batch_update_points(\n    collection_name=\"\
+            {collection_name}\",\n    update_operations=[\n        models.UpsertOperation(\n\
+            \            upsert=models.PointsList(\n                points=[\n   \
+            \                 models.PointStruct(\n                        id=1,\n\
+            \                        vector=[1.0, 2.0, 3.0, 4.0],\n              \
+            \          payload={},\n                    ),\n                ]\n  \
+            \          )\n        ),\n        models.UpdateVectorsOperation(\n   \
+            \         update_vectors=models.UpdateVectors(\n                points=[\n\
+            \                    models.PointVectors(\n                        id=1,\n\
+            \                        vector=[1.0, 2.0, 3.0, 4.0],\n              \
+            \      )\n                ]\n            )\n        ),\n        models.SetPayloadOperation(\n\
+            \            set_payload=models.SetPayload(\n                payload={\n\
+            \                    \"test_payload_2\": 2,\n                    \"test_payload_3\"\
+            : 3,\n                },\n                points=[1],\n            )\n\
+            \        ),\n    ],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf,\n\
+            \    points_update_operation::{\n        Operation, OverwritePayload,\
+            \ PointStructList, UpdateVectors,\n    },\n    PointStruct, PointVectors,\
+            \ PointsIdsList, PointsSelector, PointsUpdateOperation,\n    UpdateBatchPointsBuilder,\n\
+            };\nuse qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\nuse\
+            \ std::collections::HashMap;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .update_points_batch(\n        UpdateBatchPointsBuilder::new(\n\
+            \            \"{collection_name}\",\n            vec![\n             \
+            \   PointsUpdateOperation {\n                    operation: Some(Operation::Upsert(PointStructList\
+            \ {\n                        points: vec![PointStruct::new(\n        \
+            \                    1,\n                            vec![1.0, 2.0, 3.0,\
+            \ 4.0],\n                            Payload::try_from(json!({})).unwrap(),\n\
+            \                        )],\n                        ..Default::default()\n\
+            \                    })),\n                },\n                PointsUpdateOperation\
+            \ {\n                    operation: Some(Operation::UpdateVectors(UpdateVectors\
+            \ {\n                        points: vec![PointVectors {\n           \
+            \                 id: Some(1.into()),\n                            vectors:\
+            \ Some(vec![1.0, 2.0, 3.0, 4.0].into()),\n                        }],\n\
+            \                        ..Default::default()\n                    })),\n\
+            \                },\n                PointsUpdateOperation {\n       \
+            \             operation: Some(Operation::OverwritePayload(OverwritePayload\
+            \ {\n                        points_selector: Some(PointsSelector {\n\
+            \                            points_selector_one_of: Some(PointsSelectorOneOf::Points(\n\
+            \                                PointsIdsList {\n                   \
+            \                 ids: vec![1.into()],\n                             \
+            \   },\n                            )),\n                        }),\n\
+            \                        payload: HashMap::from([(\"test_payload\".to_string(),\
+            \ 1.into())]),\n                        ..Default::default()\n       \
+            \             })),\n                },\n            ],\n        )\n  \
+            \      .wait(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\nimport java.util.Map;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\
+            import static io.qdrant.client.ValueFactory.value;\nimport static io.qdrant.client.VectorsFactory.vectors;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Points.PointStruct;\nimport io.qdrant.client.grpc.Points.PointVectors;\n\
+            import io.qdrant.client.grpc.Points.PointsIdsList;\nimport io.qdrant.client.grpc.Points.PointsSelector;\n\
+            import io.qdrant.client.grpc.Points.PointsUpdateOperation;\nimport io.qdrant.client.grpc.Points.PointsUpdateOperation.PointStructList;\n\
+            import io.qdrant.client.grpc.Points.PointsUpdateOperation.SetPayload;\n\
+            import io.qdrant.client.grpc.Points.PointsUpdateOperation.UpdateVectors;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .batchUpdateAsync(\n\
+            \        \"{collection_name}\",\n        List.of(\n            PointsUpdateOperation.newBuilder()\n\
+            \            .setUpsert(\n                PointStructList.newBuilder()\n\
+            \                .addPoints(\n                    PointStruct.newBuilder()\n\
+            \                    .setId(id(1))\n                    .setVectors(vectors(\n\
+            \                        1.0 f,\n                        2.0 f,\n    \
+            \                    3.0 f,\n                        4.0 f))\n       \
+            \             .build())\n                .build())\n            .build(),\n\
+            \            PointsUpdateOperation.newBuilder()\n            .setUpdateVectors(\n\
+            \                UpdateVectors.newBuilder()\n                .addPoints(\n\
+            \                    PointVectors.newBuilder()\n                    .setId(id(1))\n\
+            \                    .setVectors(vectors(\n                        1.0\
+            \ f,\n                        2.0 f,\n                        3.0 f,\n\
+            \                        4.0 f))\n                    .build())\n    \
+            \            .build())\n            .build(),\n            PointsUpdateOperation.newBuilder()\n\
+            \            .setSetPayload(\n                SetPayload.newBuilder()\n\
+            \                .setPointsSelector(\n                    PointsSelector.newBuilder()\n\
+            \                    .setPoints(PointsIdsList\n                      \
+            \  .newBuilder()\n                        .addIds(id(1))\n           \
+            \             .build())\n                    .build())\n             \
+            \   .putAllPayload(\n                    Map.of(\"test_payload_2\",\n\
+            \                        value(2),\n                        \"test_payload_3\"\
+            ,\n                        value(3)))\n                .build())\n   \
+            \         .build()))\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc batchUpdate() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.UpdateBatch(context.Background(),\
+            \ &qdrant.UpdateBatchPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tOperations: []*qdrant.PointsUpdateOperation{\n\t\t\tqdrant.NewPointsUpdateUpsert(&qdrant.PointsUpdateOperation_PointStructList{\n\
+            \t\t\t\tPoints: []*qdrant.PointStruct{{\n\t\t\t\t\tId:      qdrant.NewIDNum(1),\n\
+            \t\t\t\t\tVectors: qdrant.NewVectors(1.0, 2.0, 3.0, 4.0),\n\t\t\t\t}},\n\
+            \t\t\t}),\n\t\t\tqdrant.NewPointsUpdateUpdateVectors(&qdrant.PointsUpdateOperation_UpdateVectors{\n\
+            \t\t\t\tPoints: []*qdrant.PointVectors{\n\t\t\t\t\t{\n\t\t\t\t\t\tId:\
+            \      qdrant.NewIDNum(1),\n\t\t\t\t\t\tVectors: qdrant.NewVectors(0.1,\
+            \ 0.2, 0.3, 0.4),\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t}),\n\t\t\tqdrant.NewPointsUpdateSetPayload(&qdrant.PointsUpdateOperation_SetPayload{\n\
+            \t\t\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(1)),\n\
+            \t\t\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\t\"test_payload_2\"\
+            : 2,\n\t\t\t\t\t\"test_payload_3\": 3,\n\t\t\t\t}),\n\t\t\t}),\n\t\t},\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/batch'\
+            \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'api-key:\
+            \ <api-key-value>' \\\n  --data-raw '{\n  \"operations\": [\n    {\n \
+            \     \"upsert\": {\n        \"points\": [\n          {\n            \"\
+            id\": 1,\n            \"vector\": [\n              0.4,\n            \
+            \  0.3,\n              0.2,\n              0.1\n            ]\n      \
+            \    }\n        ]\n      }\n    },\n    {\n      \"update_vectors\": {\n\
+            \        \"points\": [\n          {\n            \"id\": 1,\n        \
+            \    \"vector\": [\n              0.11,\n              0.22,\n       \
+            \       0.33,\n              0.44\n            ]\n          }\n      \
+            \  ]\n      }\n    },\n    {\n      \"set_payload\": {\n        \"payload\"\
+            : {\n          \"test_payload_2\": 2,\n          \"test_payload_3\": 3\n\
+            \        },\n        \"points\": [\n          1\n        ]\n      }\n\
+            \    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.batchUpdate(\"{collection_name}\", {\n    operations: [\n     \
+            \   {\n            upsert: {\n                points: [\n            \
+            \        {\n                        id: 1,\n                        vector:\
+            \ [1.0, 2.0, 3.0, 4.0],\n                        payload: {},\n      \
+            \              },\n                ],\n            },\n        },\n  \
+            \      {\n            update_vectors: {\n                points: [\n \
+            \                   {\n                        id: 1,\n              \
+            \          vector: [1.0, 2.0, 3.0, 4.0],\n                    },\n   \
+            \             ],\n            },\n        },\n        {\n            set_payload:\
+            \ {\n                payload: {\n                    test_payload_2: 2,\n\
+            \                    test_payload_3: 3,\n                },\n        \
+            \        points: [1],\n            },\n        },\n    ],\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/count:
+    post:
+      description: Counts the number of points that match a specified filtering condition.
+      summary: Count points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.CountAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\"\
+            , \"red\"),\n  exact: true\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.count(\n    collection_name=\"{collection_name}\"\
+            ,\n    count_filter=models.Filter(\n        must=[\n            models.FieldCondition(key=\"\
+            color\", match=models.MatchValue(value=\"red\")),\n        ]\n    ),\n\
+            \    exact=True,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, CountPointsBuilder, Filter};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .count(\n        CountPointsBuilder::new(\"\
+            {collection_name}\")\n            .filter(Filter::must([Condition::matches(\n\
+            \                \"color\",\n                \"red\".to_string(),\n  \
+            \          )]))\n            .exact(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\n\
+            import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\n\nQdrantClient client =\
+            \ new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334, false).build());\n\
+            \nclient\n    .countAsync(\n        \"{collection_name}\",\n        Filter.newBuilder().addMust(matchKeyword(\"\
+            color\", \"red\")).build(),\n        true)\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc count() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tcount, err := client.Count(context.Background(),\
+            \ &qdrant.CountPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\t\
+            qdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t},\n\t})\n\tif err\
+            \ != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Count:\", count)\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Count total number of points in a collection\ncurl  -X POST \\\n\
+            \  'http://localhost:6333/collections/collection_name/points/count' \\\
+            \n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"exact\": true\n}'\n\n# Count\
+            \ points satisfying a filter condition\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/count'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\"\
+            : [\n      {\n        \"key\": \"color\",\n        \"match\": {\n    \
+            \      \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"exact\"\
+            : true\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.count(\"{collection_name}\", {\n    filter: {\n        must: [\n\
+            \            {\n                key: \"color\",\n                match:\
+            \ {\n                    value: \"red\",\n                },\n       \
+            \     },\n        ],\n    },\n    exact: true,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/delete:
+    post:
+      description: Deletes specified points from the collection.
+      summary: Delete points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeleteAsync(collectionName: "{collection_name}", ids: [0,
+            3, 100]);
+
+
+            await client.DeleteAsync(collectionName: "{collection_name}", filter:
+            MatchKeyword("color", "red"));
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.delete(\n    collection_name=\"{collection_name}\"\
+            ,\n    points_selector=models.PointIdsList(\n        points=[0, 3, 100],\n\
+            \    ),\n)\n\nclient.delete(\n    collection_name=\"{collection_name}\"\
+            ,\n    points_selector=models.FilterSelector(\n        filter=models.Filter(\n\
+            \            must=[\n                models.FieldCondition(\n        \
+            \            key=\"color\",\n                    match=models.MatchValue(value=\"\
+            red\"),\n                ),\n            ],\n        )\n    ),\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, DeletePointsBuilder, Filter,\
+            \ PointsIdsList};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .delete_points(\n  \
+            \      DeletePointsBuilder::new(\"{collection_name}\")\n            .points(PointsIdsList\
+            \ {\n                ids: vec![0.into(), 3.into(), 100.into()],\n    \
+            \        })\n            .wait(true),\n    )\n    .await?;\n\nclient\n\
+            \    .delete_points(\n        DeletePointsBuilder::new(\"{collection_name}\"\
+            )\n            .points(Filter::must([Condition::matches(\n           \
+            \     \"color\",\n                \"red\".to_string(),\n            )]))\n\
+            \            .wait(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static\
+            \ io.qdrant.client.ConditionFactory.matchKeyword;\n\nimport java.util.List;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\n\nQdrantClient client =\
+            \ new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\"\
+            , 6334, false).build());\n\nclient.deleteAsync(\"{collection_name}\",\
+            \ List.of(id(0), id(3), id(100)));\n\nclient\n    .deleteAsync(\n    \
+            \    \"{collection_name}\",\n        Filter.newBuilder().addMust(matchKeyword(\"\
+            color\", \"red\")).build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc delete() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(), &qdrant.DeletePoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tPoints: qdrant.NewPointsSelectorIDs([]*qdrant.PointId{\n\
+            \t\t\tqdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(100),\n\t\
+            \t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\t_, err = client.Delete(context.Background(),\
+            \ &qdrant.DeletePoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tPoints: qdrant.NewPointsSelectorFilter(&qdrant.Filter{\n\t\t\tMust:\
+            \ []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\
+            \t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Delete points by IDs\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"points\": [\n    0,\n   \
+            \ 3,\n    100\n  ]\n}'\n\n# Delete points by filter \ncurl  -X POST \\\
+            \n  'http://localhost:6333/collections/collection_name/points/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\"\
+            : [\n      {\n        \"key\": \"color\",\n        \"match\": {\n    \
+            \      \"value\": \"red\"\n        }\n      }\n    ]\n  }\n}'\n"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.delete(\"{collection_name}\", {\n  points: [0, 3, 100],\n});\n\n\
+            client.delete(\"{collection_name}\", {\n    filter: {\n        must: [\n\
+            \            {\n                key: \"color\",\n                match:\
+            \ {\n                    value: \"red\",\n                },\n       \
+            \     },\n        ],\n    },\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/discover:
+    post:
+      description: 'Retrieves the most similar points to a given target, constrained
+        by the provided context.
+
+        Context Search: When only the context is provided (without a target), pairs
+        of points are used to generate a loss that guides the search towards the area
+        where most positive examples overlap. The score minimizes finding points closer
+        to a negative example than to a positive example. The maximum score a point
+        can achieve is 0.0, meaning many points may have a score of 0.0.
+
+        Target Search: When a target is provided (with or without context), the score
+        consists of two parts: the integer part represents the rank with respect to
+        the context, and the decimal part relates to the distance to the target. The
+        context score for each pair is +1 if the point is closer to a positive example
+        than to a negative example, and -1 otherwise.
+
+        '
+      summary: Discover points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.DiscoverAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  target: new TargetVector\n\
+            \  {\n    Single = new VectorExample { Vector = new float[] { 0.2f, 0.1f,\
+            \ 0.9f, 0.7f }, }\n  },\n  context:\n  [\n    new()\n    {\n      Positive\
+            \ = new VectorExample { Id = 100 },\n      Negative = new VectorExample\
+            \ { Id = 718 }\n    },\n    new()\n    {\n      Positive = new VectorExample\
+            \ { Id = 200 },\n      Negative = new VectorExample { Id = 300 }\n   \
+            \ }\n  ],\n  limit: 10\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.discover(\n    \"{collection_name}\"\
+            ,\n    target=[0.2, 0.1, 0.9, 0.7],\n    context=[\n        models.ContextExamplePair(positive=100,\
+            \ negative=718),\n        models.ContextExamplePair(positive=200, negative=300),\n\
+            \    ],\n    limit=10,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    target_vector::Target, vector_example::Example,\
+            \ ContextExamplePairBuilder,\n    DiscoverPointsBuilder, VectorExample,\n\
+            };\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .discover(\n        DiscoverPointsBuilder::new(\n\
+            \            \"{collection_name}\",\n            vec![\n             \
+            \   ContextExamplePairBuilder::default()\n                    .positive(Example::Id(100.into()))\n\
+            \                    .negative(Example::Id(718.into()))\n            \
+            \        .build(),\n                ContextExamplePairBuilder::default()\n\
+            \                    .positive(Example::Id(200.into()))\n            \
+            \        .negative(Example::Id(300.into()))\n                    .build(),\n\
+            \            ],\n            10,\n        )\n        .target(Target::Single(VectorExample\
+            \ {\n            example: Some(Example::Vector(vec![0.2, 0.1, 0.9, 0.7].into())),\n\
+            \        })),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\
+            import static io.qdrant.client.VectorFactory.vector;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.ContextExamplePair;\n\
+            import io.qdrant.client.grpc.Points.DiscoverPoints;\nimport io.qdrant.client.grpc.Points.TargetVector;\n\
+            import io.qdrant.client.grpc.Points.VectorExample;\n\nQdrantClient client\
+            \ =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334,\
+            \ false).build());\n\nclient\n    .discoverAsync(\n        DiscoverPoints.newBuilder()\n\
+            \            .setCollectionName(\"{collection_name}\")\n            .setTarget(\n\
+            \                TargetVector.newBuilder()\n                    .setSingle(\n\
+            \                        VectorExample.newBuilder()\n                \
+            \            .setVector(vector(0.2f, 0.1f, 0.9f, 0.7f))\n            \
+            \                .build()))\n            .addAllContext(\n           \
+            \     List.of(\n                    ContextExamplePair.newBuilder()\n\
+            \                        .setPositive(VectorExample.newBuilder().setId(id(100)))\n\
+            \                        .setNegative(VectorExample.newBuilder().setId(id(718)))\n\
+            \                        .build(),\n                    ContextExamplePair.newBuilder()\n\
+            \                        .setPositive(VectorExample.newBuilder().setId(id(200)))\n\
+            \                        .setNegative(VectorExample.newBuilder().setId(id(300)))\n\
+            \                        .build()))\n            .setLimit(10)\n     \
+            \       .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc discover() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.Query(context.Background(),\
+            \ &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\t\t\tTarget:\
+            \ qdrant.NewVectorInput(0.2, 0.1, 0.9, 0.7),\n\t\t\tContext: &qdrant.ContextInput{\n\
+            \t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\t\
+            \t\t\t}, {\n\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\
+            \t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\t\
+            \t\t\t}},\n\t\t\t},\n\t\t}),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\
+            \t}\n\tfmt.Println(\"Results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/discover'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"target\": [\n    0.2,\n \
+            \   0.1,\n    0.9,\n    0.7\n  ],\n  \"context\": [\n    {\n      \"positive\"\
+            : \"7f6652c4-89bd-40e0-ab1d-510f7fcddd2b\",\n      \"negative\": \"2c2c9f86-0171-4bd2-9ab0-b4754682cddd\"\
+            \n    }\n  ],\n  \"limit\": 10\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.discover(\"{collection_name}\", {\n    target: [0.2, 0.1, 0.9,\
+            \ 0.7],\n    context: [\n        {\n            positive: 100,\n     \
+            \       negative: 718,\n        },\n        {\n            positive: 200,\n\
+            \            negative: 300,\n        },\n    ],\n    limit: 10,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/discover/batch:
+    post:
+      description: Retrieves points in batches based on the target and/or positive
+        and negative example pairs.
+      summary: Discover batch points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nvar discoverPoints = new List<DiscoverPoints>\n\
+            {\n    new DiscoverPoints\n    {\n        CollectionName = \"{collection_name}\"\
+            ,\n        Target = new TargetVector\n        {\n            Single =\
+            \ new VectorExample { Vector = new float[] { 0.2f, 0.1f, 0.9f, 0.7f },\
+            \ }\n        },\n        Context =\n        {\n            new ContextExamplePair()\n\
+            \            {\n                Positive = new VectorExample { Id = 100\
+            \ },\n                Negative = new VectorExample { Id = 718 }\n    \
+            \        },\n            new ContextExamplePair()\n            {\n   \
+            \             Positive = new VectorExample { Id = 200 },\n           \
+            \     Negative = new VectorExample { Id = 300 }\n            }\n     \
+            \   },\n        Limit = 10\n    },\n    new DiscoverPoints\n    {\n  \
+            \      CollectionName = \"{collection_name}\",\n        Target = new TargetVector\n\
+            \        {\n            Single = new VectorExample { Vector = new float[]\
+            \ { 0.5f, 0.3f, 0.2f, 0.3f }, }\n        },\n        Context =\n     \
+            \   {\n            new ContextExamplePair()\n            {\n         \
+            \       Positive = new VectorExample { Id = 342 },\n                Negative\
+            \ = new VectorExample { Id = 213 }\n            },\n            new ContextExamplePair()\n\
+            \            {\n                Positive = new VectorExample { Id = 100\
+            \ },\n                Negative = new VectorExample { Id = 200 }\n    \
+            \        }\n        },\n        Limit = 10\n    }\n};\nawait client.DiscoverBatchAsync(\"\
+            {collection_name}\", discoverPoints);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\ndiscover_queries = [\n    models.DiscoverRequest(\n\
+            \        target=[0.2, 0.1, 0.9, 0.7],\n        context=[\n           \
+            \ models.ContextExamplePair(\n                positive=100,\n        \
+            \        negative=718,\n            ),\n            models.ContextExamplePair(\n\
+            \                positive=200,\n                negative=300,\n      \
+            \      ),\n        ],\n        limit=10,\n    ),\n    models.DiscoverRequest(\n\
+            \        target=[0.5, 0.3, 0.2, 0.3],\n        context=[\n           \
+            \ models.ContextExamplePair(\n                positive=342,\n        \
+            \        negative=213,\n            ),\n            models.ContextExamplePair(\n\
+            \                positive=100,\n                negative=200,\n      \
+            \      ),\n        ],\n        limit=5,\n    ),\n]\n\nclient.discover_batch(\"\
+            {collection_name}\", discover_queries)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    vector_example::Example, ContextExamplePairBuilder,\
+            \ DiscoverBatchPointsBuilder,\n    DiscoverPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\
+            \nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\
+            \nlet discover_points = DiscoverBatchPointsBuilder::new(\n    \"{collection_name}\"\
+            ,\n    vec![\n        DiscoverPointsBuilder::new(\n            \"{collection_name}\"\
+            ,\n            vec![\n                ContextExamplePairBuilder::default()\n\
+            \                    .positive(Example::Id(100.into()))\n            \
+            \        .negative(Example::Id(718.into()))\n                    .build(),\n\
+            \                ContextExamplePairBuilder::default()\n              \
+            \      .positive(Example::Id(200.into()))\n                    .negative(Example::Id(300.into()))\n\
+            \                    .build(),\n            ],\n            10,\n    \
+            \    )\n        .build(),\n        DiscoverPointsBuilder::new(\n     \
+            \       \"{collection_name}\",\n            vec![\n                ContextExamplePairBuilder::default()\n\
+            \                    .positive(Example::Id(342.into()))\n            \
+            \        .negative(Example::Id(213.into()))\n                    .build(),\n\
+            \                ContextExamplePairBuilder::default()\n              \
+            \      .positive(Example::Id(100.into()))\n                    .negative(Example::Id(200.into()))\n\
+            \                    .build(),\n            ],\n            10,\n    \
+            \    )\n        .build(),\n    ],\n);\n\nclient.discover_batch(&discover_points.build()).await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static\
+            \ io.qdrant.client.VectorFactory.vector;\n\nimport java.util.Arrays;\n\
+            import java.util.List;\n\nimport io.qdrant.client.QdrantClient;\nimport\
+            \ io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.ContextExamplePair;\n\
+            import io.qdrant.client.grpc.Points.DiscoverPoints;\nimport io.qdrant.client.grpc.Points.TargetVector;\n\
+            import io.qdrant.client.grpc.Points.VectorExample;\n\nQdrantClient client\
+            \ = new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334,\
+            \ false).build());\n\nList <DiscoverPoints> discoverPoints = Arrays.asList(\n\
+            \    DiscoverPoints.newBuilder()\n    .setCollectionName(\"{collection_name}\"\
+            )\n    .setTarget(\n        TargetVector.newBuilder()\n        .setSingle(\n\
+            \            VectorExample.newBuilder()\n            .setVector(vector(\n\
+            \                0.2 f,\n                0.1 f,\n                0.9 f,\n\
+            \                0.7 f))\n            .build()))\n    .addAllContext(\n\
+            \        List.of(\n            ContextExamplePair.newBuilder()\n     \
+            \       .setPositive(VectorExample\n                .newBuilder()\n  \
+            \              .setId(id(100)))\n            .setNegative(VectorExample\n\
+            \                .newBuilder()\n                .setId(id(718)))\n   \
+            \         .build(),\n            ContextExamplePair.newBuilder()\n   \
+            \         .setPositive(VectorExample\n                .newBuilder()\n\
+            \                .setId(id(200)))\n            .setNegative(VectorExample\n\
+            \                .newBuilder()\n                .setId(id(300)))\n   \
+            \         .build()))\n    .setLimit(10)\n    .build(),\n    DiscoverPoints.newBuilder()\n\
+            \    .setCollectionName(\"{collection_name}\")\n    .setTarget(\n    \
+            \    TargetVector.newBuilder()\n        .setSingle(\n            VectorExample.newBuilder()\n\
+            \            .setVector(vector(\n                0.5 f, 0.3 f, 0.2 f,\
+            \ 0.3 f))\n            .build()))\n    .addAllContext(\n        List.of(\n\
+            \            ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n\
+            \                .newBuilder()\n                .setId(id(342)))\n   \
+            \         .setNegative(VectorExample\n                .newBuilder()\n\
+            \                .setId(id(213)))\n            .build(),\n           \
+            \ ContextExamplePair.newBuilder()\n            .setPositive(VectorExample\n\
+            \                .newBuilder()\n                .setId(id(100)))\n   \
+            \         .setNegative(VectorExample\n                .newBuilder()\n\
+            \                .setId(id(200)))\n            .build()))\n    .setLimit(10)\n\
+            \    .build());\nclient.discoverBatchAsync(\"{collection_name}\", discoverPoints,\
+            \ null);\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc discoverBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(),\
+            \ &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName:\
+            \ \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\
+            \t\t\t\t\tTarget: qdrant.NewVectorInput(0.2, 0.1, 0.9, 0.7),\n\t\t\t\t\
+            \tContext: &qdrant.ContextInput{\n\t\t\t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\
+            \t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\
+            \t\t\t\t\t\t}, {\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\
+            \t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\
+            \t\t\t\t\t\t}},\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\t\
+            CollectionName: \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{\n\
+            \t\t\t\t\tTarget: qdrant.NewVectorInput(0.5, 0.3, 0.2, 0.3),\n\t\t\t\t\
+            \tContext: &qdrant.ContextInput{\n\t\t\t\t\t\tPairs: []*qdrant.ContextInputPair{{\n\
+            \t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(342)),\n\
+            \t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(213)),\n\
+            \t\t\t\t\t\t}, {\n\t\t\t\t\t\t\tPositive: qdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\t\t\t\tNegative: qdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\
+            \t\t\t\t\t\t}},\n\t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\t\
+            if err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n\
+            }\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/discover/batch'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n  \
+            \    \"target\": [\n        0.2,\n        0.1,\n        0.9,\n       \
+            \ 0.7\n      ],\n      \"context\": [\n        {\n          \"positive\"\
+            : \"7f6652c4-89bd-40e0-ab1d-510f7fcddd2b\",\n          \"negative\": \"\
+            2c2c9f86-0171-4bd2-9ab0-b4754682cddd\"\n        }\n      ],\n      \"\
+            limit\": 1\n    },\n    {\n      \"target\": [\n        0.5,\n       \
+            \ 0.3,\n        0.2,\n        0.3\n      ],\n      \"context\": [\n  \
+            \      {\n          \"positive\": 342,\n          \"negative\": 213\n\
+            \        }\n      ],\n      \"limit\": 1\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            const searches = [\n    {\n        target: [0.2, 0.1, 0.9, 0.7],\n   \
+            \     context: [\n            {\n                positive: 100,\n    \
+            \            negative: 718,\n            },\n            {\n         \
+            \       positive: 200,\n                negative: 300,\n            },\n\
+            \        ],\n        limit: 10,\n    },\n    {\n        target: [0.5,\
+            \ 0.3, 0.2, 0.3],\n        context: [\n            {\n               \
+            \ positive: 342,\n                negative: 213,\n            },\n   \
+            \         {\n                positive: 100,\n                negative:\
+            \ 200,\n            },\n        ],\n        limit: 5,\n    },\n];\n\n\
+            client.discoverBatchPoints(\"{collection_name}\", {\n    searches,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/payload:
+    post:
+      description: Sets payload values for specified points.
+      summary: Set payload
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.SetPayloadAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string,\
+            \ Value> { { \"property1\", \"string\" }, { \"property2\", \"string\"\
+            \ } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.set_payload(\n    collection_name=\"\
+            {collection_name}\",\n    payload={\n        \"property1\": \"string\"\
+            ,\n        \"property2\": \"string\",\n    },\n    points=[0, 3, 10],\n\
+            )\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};\n\
+            use qdrant_client::{Qdrant, Payload};\nuse serde_json::json;\n\nlet client\
+            \ = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet payload:\
+            \ Payload = json!({\n    \"property1\": \"string\",\n    \"property2\"\
+            : \"string\",\n})\n.try_into()\n.unwrap();\n\nclient\n    .set_payload(\n\
+            \        SetPayloadPointsBuilder::new(\"{collection_name}\", payload)\n\
+            \            .points_selector(PointsIdsList {\n                ids: vec![0.into(),\
+            \ 3.into(), 10.into()],\n            })\n            .wait(true),\n  \
+            \  )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static\
+            \ io.qdrant.client.ValueFactory.value;\n\nimport java.util.List;\nimport\
+            \ java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .setPayloadAsync(\n\
+            \        \"{collection_name}\",\n        Map.of(\"property1\", value(\"\
+            string\"), \"property2\", value(\"string\")),\n        List.of(id(0),\
+            \ id(3), id(10)),\n        true,\n        null,\n        null)\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc setPayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.SetPayload(context.Background(),\
+            \ &qdrant.SetPayloadPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\"property1\"\
+            : \"string\",\n\t\t\t\"property2\": \"string\",\n\t\t}),\n\t\tPointsSelector:\
+            \ qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(10)),\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results:\
+            \ \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Set payload by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\"\
+            : \"some_value\",\n    \"property2\": 32,\n    \"property3\": true\n \
+            \ },\n  \"points\": [\n    0,\n    3,\n    10\n  ]\n}'\n\n# Set payload\
+            \ by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\"\
+            : [\n      {\n        \"key\": \"color\",\n        \"match\": {\n    \
+            \      \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"payload\"\
+            : {\n    \"property1\": \"some_value\",\n    \"property2\": 32,\n    \"\
+            property3\": true\n  }\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.setPayload(\"{collection_name}\", {\n  payload: {\n    property1:\
+            \ \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n\
+            });\n"
+          language: typescript
+    put:
+      description: Replaces the entire payload of a specified point with a new payload.
+      summary: Overwrite payload
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.OverwritePayloadAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  payload: new Dictionary<string,\
+            \ Value> { { \"property1\", \"string\" }, { \"property2\", \"string\"\
+            \ } },\n  ids: new ulong[] { 0, 3, 10 }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.overwrite_payload(\n    collection_name=\"\
+            {collection_name}\",\n    payload={\n        \"property1\": \"string\"\
+            ,\n        \"property2\": \"string\",\n    },\n    points=[0, 3, 10],\n\
+            )\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    points_selector::PointsSelectorOneOf,\
+            \ PointsIdsList, SetPayloadPointsBuilder,\n};\nuse qdrant_client::{Qdrant,\
+            \ Payload};\nuse serde_json::json;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nlet payload: Payload = json!({\n\
+            \    \"property1\": \"string\",\n    \"property2\": \"string\",\n})\n\
+            .try_into()\n.unwrap();\n\nclient\n    .overwrite_payload(\n        SetPayloadPointsBuilder::new(\"\
+            {collection_name}\", payload)\n            .points_selector(PointsSelectorOneOf::Points(PointsIdsList\
+            \ {\n                ids: vec![0.into(), 3.into(), 10.into()],\n     \
+            \       }))\n            .wait(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\
+            import static io.qdrant.client.ValueFactory.value;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new\
+            \ QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\"\
+            , 6334, false).build());\n\nclient\n    .overwritePayloadAsync(\n    \
+            \    \"{collection_name}\",\n        Map.of(\"property1\", value(\"string\"\
+            ), \"property2\", value(\"string\")),\n        List.of(id(0), id(3), id(10)),\n\
+            \        true,\n        null,\n        null)\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc overwritePayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.OverwritePayload(context.Background(),\
+            \ &qdrant.SetPayloadPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPayload: qdrant.NewValueMap(map[string]any{\n\t\t\t\"property1\"\
+            : \"string\",\n\t\t\t\"property2\": \"string\",\n\t\t}),\n\t\tPointsSelector:\
+            \ qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3), qdrant.NewIDNum(10)),\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Overwrite payload by ID\ncurl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/payload'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\"\
+            : \"string\",\n    \"property2\": \"string\"\n  },\n  \"points\": [\n\
+            \    0,\n    3,\n    10\n  ]\n}'\n\n# Overwrite payload by filter\ncurl\
+            \  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/payload'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"payload\": {\n    \"property1\"\
+            : \"string\",\n    \"property2\": \"string\"\n  },\n  \"filter\": {\n\
+            \    \"must\": [\n      {\n        \"key\": \"color\",\n        \"match\"\
+            : {\n          \"value\": \"red\"\n        }\n      }\n    ]\n  }\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.overwritePayload(\"{collection_name}\", {\n  payload: {\n    property1:\
+            \ \"string\",\n    property2: \"string\",\n  },\n  points: [0, 3, 10],\n\
+            });\n"
+          language: typescript
+  /collections/{collection_name}/points/payload/clear:
+    post:
+      description: Removes the entire payload for specified points.
+      summary: Clear payload
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ClearPayloadAsync("{collection_name}", [0, 3, 10]);
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.clear_payload(\n    collection_name=\"\
+            {collection_name}\",\n    points_selector=[0, 3, 100],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{ClearPayloadPointsBuilder, PointsIdsList};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .clear_payload(ClearPayloadPointsBuilder::new(\"\
+            {collection_name}\").points(\n        PointsIdsList {\n            ids:\
+            \ vec![0.into(), 3.into(), 100.into()],\n        },\n    ))\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.clearPayloadAsync(\"{collection_name}\"\
+            , List.of(id(0), id(3), id(100)), null, null, null)\n                .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc clearPayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.ClearPayload(context.Background(),\
+            \ &qdrant.ClearPayloadPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPoints:         qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewID(\"\
+            3\"), qdrant.NewIDNum(100)),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\
+            \t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/clear'\
+            \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'api-key:\
+            \ <api-key-value>' \\\n  --data-raw '{\n  \"points\": [\n    0,\n    3,\n\
+            \    100\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.clearPayload(\"{collection_name}\", {\n  points: [0, 3, 100],\n\
+            });\n"
+          language: typescript
+  /collections/{collection_name}/points/payload/delete:
+    post:
+      description: Deletes a specified key payload for points.
+      summary: Delete payload
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeletePayloadAsync("{collection_name}", ["color", "price"],
+            [0, 3, 10]);
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.delete_payload(\n    collection_name=\"\
+            {collection_name}\",\n    keys=[\"color\", \"price\"],\n    points=[0,\
+            \ 3, 100],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{DeletePayloadPointsBuilder, PointsIdsList};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .delete_payload(\n        DeletePayloadPointsBuilder::new(\n\
+            \            \"{collection_name}\",\n            vec![\"color\".to_string(),\
+            \ \"price\".to_string()],\n        )\n        .points_selector(PointsIdsList\
+            \ {\n            ids: vec![0.into(), 3.into(), 100.into()],\n        })\n\
+            \        .wait(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.PointIdFactory.id;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .deletePayloadAsync(\n\
+            \        \"{collection_name}\",\n        List.of(\"color\", \"price\"\
+            ),\n        List.of(id(0), id(3), id(100)),\n        true,\n        null,\n\
+            \        null)\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deletePayload() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.DeletePayload(context.Background(),\
+            \ &qdrant.DeletePayloadPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3),\
+            \ qdrant.NewIDNum(100)),\n\t\tKeys:           []string{\"color\", \"price\"\
+            },\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Delete payload by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"keys\": [\n    \"color\"\
+            ,\n    \"price\"\n  ],\n  \"points\": [\n    0,\n    3,\n    100\n  ]\n\
+            }'\n\n# Delete payload by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/payload/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"keys\": [\n    \"color\"\
+            ,\n    \"price\"\n  ],\n  \"filter\": {\n    \"must\": [\n      {\n  \
+            \      \"key\": \"color\",\n        \"match\": {\n          \"value\"\
+            : \"red\"\n        }\n      }\n    ]\n  }\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.deletePayload(\"{collection_name}\", {\n  keys: [\"color\", \"\
+            price\"],\n  points: [0, 3, 100],\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/query:
+    post:
+      description: Universally query points. This endpoint covers all capabilities
+        of search, recommend, discover, filters. But also enables hybrid and multi-stage
+        queries.
+      summary: Query points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\n// Query nearest by ID\nawait\
+            \ client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tquery:\
+            \ Guid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")\n);\n\n// Recommend\
+            \ on the average of these vectors\nawait client.QueryAsync(\n\tcollectionName:\
+            \ \"{collection_name}\",\n\tquery: new RecommendInput\n\t{\n\t\tPositive\
+            \ =\n\t\t{\n\t\t\tGuid.Parse(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\
+            ),\n\t\t\tnew float[] { 0.11f, 0.35f, 0.6f }\n\t\t},\n\t\tNegative = {\
+            \ new float[] { 0.01f, 0.45f, 0.67f } }\n\t}\n);\n\n// Fusion query\n\
+            await client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\t\
+            prefetch: new List<PrefetchQuery>\n\t{\n\t\tnew()\n\t\t{\n\t\t\tQuery\
+            \ = new (float, uint)[] { (0.22f, 1), (0.8f, 42), },\n\t\t\tUsing = \"\
+            sparse\",\n\t\t\tLimit = 20\n\t\t},\n\t\tnew()\n\t\t{\n\t\t\tQuery = new\
+            \ float[] { 0.01f, 0.45f, 0.67f },\n\t\t\tUsing = \"dense\",\n\t\t\tLimit\
+            \ = 20\n\t\t}\n\t},\n\tquery: Fusion.Rrf\n);\n\n// 2-stage query\nawait\
+            \ client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\tprefetch:\
+            \ new List<PrefetchQuery>\n\t{\n\t\tnew() { Query = new float[] { 0.01f,\
+            \ 0.45f, 0.67f }, Limit = 100 }\n\t},\n\tquery: new float[][] { [0.1f,\
+            \ 0.2f], [0.2f, 0.1f], [0.8f, 0.9f] },\n\tusingVector: \"colbert\",\n\t\
+            limit: 10\n);\n\n// Random sampling (as of 1.11.0)\nawait client.QueryAsync(\n\
+            \    collectionName: \"{collection_name}\",\n    query: Sample.Random\n\
+            );\n\n// Score boost depending on payload conditions (as of 1.14.0)\n\
+            await client.QueryAsync(\n\tcollectionName: \"{collection_name}\",\n\t\
+            prefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f, 0.45f,\
+            \ 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\tExpression\
+            \ = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"$score\"\
+            ,\n\t\t\t\tnew MultExpression\n\t\t\t\t{\n\t\t\t\t\tMult = { 0.5f, Match(\"\
+            tag\", [\"h1\", \"h2\", \"h3\", \"h4\"]) },\n\t\t\t\t},\n\t\t\t\tnew MultExpression\
+            \ { Mult = { 0.25f, Match(\"tag\", [\"p\", \"li\"]) } },\n\t\t\t},\n\t\
+            \t},\n\t},\n\tlimit: 10\n);\n\n// Score boost geographically closer points\
+            \ (as of 1.14.0)\nawait client.QueryAsync(\n\tcollectionName: \"{collection_name}\"\
+            ,\n\tprefetch:\n\t[\n\t\tnew PrefetchQuery { Query = new float[] { 0.01f,\
+            \ 0.45f, 0.67f }, Limit = 100 },\n\t],\n\tquery: new Formula\n\t{\n\t\t\
+            Expression = new SumExpression\n\t\t{\n\t\t\tSum =\n\t\t\t{\n\t\t\t\t\"\
+            $score\",\n\t\t\t\tWithExpDecay(\n\t\t\t\t\tnew()\n\t\t\t\t\t{\n\t\t\t\
+            \t\t\tX = new GeoDistance\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\tOrigin = new GeoPoint\
+            \ { Lat = 52.504043, Lon = 13.393236 },\n\t\t\t\t\t\t\tTo = \"geo.location\"\
+            ,\n\t\t\t\t\t\t},\n\t\t\t\t\t\tScale = 5000,\n\t\t\t\t\t}\n\t\t\t\t),\n\
+            \t\t\t},\n\t\t},\n\t\tDefaults =\n\t\t{\n\t\t\t[\"geo.location\"] = new\
+            \ Dictionary<string, Value>\n\t\t\t{\n\t\t\t\t[\"lat\"] = 48.137154,\n\
+            \t\t\t\t[\"lon\"] = 11.576124,\n\t\t\t},\n\t\t},\n\t}\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\n# Query nearest by ID\nnearest = client.query_points(\n\
+            \    collection_name=\"{collection_name}\",\n    query=\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\
+            ,\n)\n\n# Recommend on the average of these vectors\nrecommended = client.query_points(\n\
+            \    collection_name=\"{collection_name}\",\n    query=models.RecommendQuery(recommend=models.RecommendInput(\n\
+            \        positive=[\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\", [0.11, 0.35,\
+            \ 0.6, ...]],\n        negative=[[0.01, 0.45, 0.67, ...]]\n    ))\n)\n\
+            \n# Fusion query\nhybrid = client.query_points(\n    collection_name=\"\
+            {collection_name}\",\n    prefetch=[\n        models.Prefetch(\n     \
+            \       query=models.SparseVector(indices=[1, 42], values=[0.22, 0.8]),\n\
+            \            using=\"sparse\",\n            limit=20,\n        ),\n  \
+            \      models.Prefetch(\n            query=[0.01, 0.45, 0.67, ...],  #\
+            \ <-- dense vector\n            using=\"dense\",\n            limit=20,\n\
+            \        ),\n    ],\n    query=models.FusionQuery(fusion=models.Fusion.RRF),\n\
+            )\n\n# 2-stage query\nrefined = client.query_points(\n    collection_name=\"\
+            {collection_name}\",\n    prefetch=models.Prefetch(\n        query=[0.01,\
+            \ 0.45, 0.67, ...],  # <-- dense vector\n        limit=100,\n    ),\n\
+            \    query=[\n        [0.1, 0.2, ...],  # <\u2500\u2510\n        [0.2,\
+            \ 0.1, ...],  # < \u251C\u2500 multi-vector\n        [0.8, 0.9, ...],\
+            \  # < \u2518\n    ],\n    using=\"colbert\",\n    limit=10,\n)\n\n# Random\
+            \ sampling (as of 1.11.0)\nsampled = client.query_points(\n    collection_name=\"\
+            {collection_name}\",\n    query=models.SampleQuery(sample=models.Sample.RANDOM)\n\
+            )\n\n# Score boost depending on payload conditions (as of 1.14.0)\ntag_boosted\
+            \ = client.query_points(\n    collection_name=\"{collection_name}\",\n\
+            \    prefetch=models.Prefetch(\n        query=[0.2, 0.8, ...],  # <--\
+            \ dense vector\n        limit=50\n    ),\n    query=models.FormulaQuery(\n\
+            \        formula=models.SumExpression(sum=[\n            \"$score\",\n\
+            \            models.MultExpression(mult=[0.5, models.FieldCondition(key=\"\
+            tag\", match=models.MatchAny(any=[\"h1\", \"h2\", \"h3\", \"h4\"]))]),\n\
+            \            models.MultExpression(mult=[0.25, models.FieldCondition(key=\"\
+            tag\", match=models.MatchAny(any=[\"p\", \"li\"]))])\n        ]\n    ))\n\
+            )\n\n# Score boost geographically closer points (as of 1.14.0)\ngeo_boosted\
+            \ = client.query_points(\n    collection_name=\"{collection_name}\",\n\
+            \    prefetch=models.Prefetch(\n        query=[0.2, 0.8, ...],  # <--\
+            \ dense vector\n        limit=50\n    ),\n    query=models.FormulaQuery(\n\
+            \        formula=models.SumExpression(sum=[\n            \"$score\",\n\
+            \            models.GaussDecayExpression(\n                gauss_decay=models.DecayParamsExpression(\n\
+            \                    x=models.GeoDistance(\n                        geo_distance=models.GeoDistanceParams(\n\
+            \                            origin=models.GeoPoint(\n               \
+            \                 lat=52.504043,\n                                lon=13.393236\n\
+            \                            ),  # Berlin\n                          \
+            \  to=\"geo.location\"\n                        )\n                  \
+            \  ),\n                    scale=5000  # 5km\n                )\n    \
+            \        )\n        ]),\n        defaults={\"geo.location\": models.GeoPoint(lat=48.137154,\
+            \ lon=11.576124)}  # Munich\n    )\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    Condition, DecayParamsExpressionBuilder,\
+            \ Expression, FormulaBuilder, Fusion, GeoPoint,\n    PointId, PrefetchQueryBuilder,\
+            \ Query, QueryPointsBuilder, RecommendInputBuilder,\n    Sample,\n};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\n// Query nearest by ID\nlet _nearest = client.query(\n\
+            \    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(PointId::from(\"\
+            43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"))\n).await?;\n\n// Recommend on\
+            \ the average of these vectors\nlet _recommendations = client.query(\n\
+            \    QueryPointsBuilder::new(\"{collection_name}\")\n        .query(Query::new_recommend(\n\
+            \            RecommendInputBuilder::default()\n                .add_positive(vec![0.1;\
+            \ 8])\n                .add_negative(PointId::from(0))\n        ))\n).await?;\n\
+            \n// Fusion query\nlet _hybrid = client.query(\n    QueryPointsBuilder::new(\"\
+            {collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n\
+            \            .query(vec![(1, 0.22), (42, 0.8)])\n            .using(\"\
+            sparse\")\n            .limit(20u64)\n        )\n        .add_prefetch(PrefetchQueryBuilder::default()\n\
+            \            .query(vec![0.01, 0.45, 0.67])\n            .using(\"dense\"\
+            )\n            .limit(20u64)\n        )\n        .query(Fusion::Rrf)\n\
+            ).await?;\n\n// 2-stage query\nlet _refined = client.query(\n    QueryPointsBuilder::new(\"\
+            {collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n\
+            \            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n\
+            \        )\n        .query(vec![\n            vec![0.1, 0.2],\n      \
+            \      vec![0.2, 0.1],\n            vec![0.8, 0.9],\n        ])\n    \
+            \    .using(\"colbert\")\n        .limit(10u64)\n).await?;\n\n// Random\
+            \ sampling (as of 1.11.0)\nlet _sampled = client\n    .query(\n      \
+            \  QueryPointsBuilder::new(\"{collection_name}\")\n            .query(Query::new_sample(Sample::Random))\n\
+            \    )\n    .await?;\n\n// Score boost depending on payload conditions\
+            \ (as of 1.14.0)\nlet _tag_boosted = client.query(\n    QueryPointsBuilder::new(\"\
+            {collection_name}\")\n        .add_prefetch(PrefetchQueryBuilder::default()\n\
+            \            .query(vec![0.01, 0.45, 0.67])\n            .limit(100u64)\n\
+            \        )\n        .query(FormulaBuilder::new(Expression::sum_with([\n\
+            \            Expression::score(),\n            Expression::mult_with([\n\
+            \                Expression::constant(0.5),\n                Expression::condition(Condition::matches(\"\
+            tag\", [\"h1\", \"h2\", \"h3\", \"h4\"])),\n            ]),\n        \
+            \    Expression::mult_with([\n                Expression::constant(0.25),\n\
+            \                Expression::condition(Condition::matches(\"tag\", [\"\
+            p\", \"li\"])),\n            ]),\n        ])))\n        .limit(10)\n \
+            \   ).await?;\n\n// Score boost geographically closer points (as of 1.14.0)\n\
+            let _geo_boosted = client.query(\n    QueryPointsBuilder::new(\"{collection_name}\"\
+            )\n            .add_prefetch(\n                PrefetchQueryBuilder::default()\n\
+            \                    .query(vec![0.01, 0.45, 0.67])\n                \
+            \    .limit(100u64),\n            )\n            .query(\n           \
+            \     FormulaBuilder::new(Expression::sum_with([\n                   \
+            \ Expression::score(),\n                    Expression::exp_decay(\n \
+            \                       DecayParamsExpressionBuilder::new(Expression::geo_distance_with(\n\
+            \                            // Berlin\n                            GeoPoint\
+            \ { lat: 52.504043, lon: 13.393236 },\n                            \"\
+            geo.location\",\n                        ))\n                        .scale(5_000.0),\n\
+            \                    ),\n                ]))\n                // Munich\n\
+            \                .add_default(\"geo.location\", GeoPoint { lat: 48.137154,\
+            \ lon: 11.576124 }),\n            )\n            .limit(10),\n    )\n\
+            \    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.QueryFactory.fusion;\nimport static\
+            \ io.qdrant.client.QueryFactory.nearest;\nimport static io.qdrant.client.QueryFactory.recommend;\n\
+            import static io.qdrant.client.VectorInputFactory.vectorInput;\n\nimport\
+            \ java.util.UUID;\n\nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            import io.qdrant.client.grpc.Points.Fusion;\nimport io.qdrant.client.grpc.Points.PrefetchQuery;\n\
+            import io.qdrant.client.grpc.Points.QueryPoints;\nimport io.qdrant.client.grpc.Points.RecommendInput;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\n// Query nearest by ID\nclient\n\
+            \    .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .setQuery(nearest(UUID.fromString(\"\
+            43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")))\n            .build())\n   \
+            \ .get();\n\n// Recommend on the average of these vectors\nclient\n  \
+            \  .queryAsync(\n        QueryPoints.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .setQuery(\n                recommend(\n\
+            \                    RecommendInput.newBuilder()\n                   \
+            \     .addPositive(vectorInput(UUID.fromString(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\
+            )))\n                        .addPositive(vectorInput(0.11f, 0.35f, 0.6f))\n\
+            \                        .addNegative(vectorInput(0.01f, 0.45f, 0.67f))\n\
+            \                        .build()))\n            .build())\n    .get();\n\
+            \n// Fusion query\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n\
+            \            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n\
+            \                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(List.of(0.22f,\
+            \ 0.8f), List.of(1, 42)))\n                    .setUsing(\"sparse\")\n\
+            \                    .setLimit(20)\n                    .build())\n  \
+            \          .addPrefetch(\n                PrefetchQuery.newBuilder()\n\
+            \                    .setQuery(nearest(List.of(0.01f, 0.45f, 0.67f)))\n\
+            \                    .setUsing(\"dense\")\n                    .setLimit(20)\n\
+            \                    .build())\n            .setQuery(fusion(Fusion.RRF))\n\
+            \            .build())\n    .get();\n\n// 2-stage query\nclient\n    .queryAsync(\n\
+            \        QueryPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\"\
+            )\n            .addPrefetch(\n                PrefetchQuery.newBuilder()\n\
+            \                    .setQuery(nearest(0.01f, 0.45f, 0.67f))\n       \
+            \             .setLimit(100)\n                    .build())\n        \
+            \    .setQuery(\n                nearest(\n                    new float[][]\
+            \ {\n                      {0.1f, 0.2f},\n                      {0.2f,\
+            \ 0.1f},\n                      {0.8f, 0.9f}\n                    }))\n\
+            \            .setUsing(\"colbert\")\n            .setLimit(10)\n     \
+            \       .build())\n    .get();\n\n// Random sampling (as of 1.11.0)\n\
+            client\n    .queryAsync(\n        QueryPoints.newBuilder()\n         \
+            \   .setCollectionName(\"{collection_name}\")\n            .setQuery(sample(Sample.Random))\n\
+            \            .build())\n    .get();\n\n// Score boost depending on payload\
+            \ conditions (as of 1.14.0)\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n\
+            \            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n\
+            \                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(0.01f,\
+            \ 0.45f, 0.67f))\n                    .setLimit(100)\n               \
+            \     .build())\n            .setQuery(\n                formula(\n  \
+            \                  Formula.newBuilder()\n                        .setExpression(\n\
+            \                            sum(\n                                SumExpression.newBuilder()\n\
+            \                                    .addSum(variable(\"$score\"))\n \
+            \                                   .addSum(\n                       \
+            \                 mult(\n                                            MultExpression.newBuilder()\n\
+            \                                                .addMult(constant(0.5f))\n\
+            \                                                .addMult(\n         \
+            \                                           condition(\n             \
+            \                                           matchKeywords(\n         \
+            \                                                   \"tag\",\n       \
+            \                                                     List.of(\"h1\",\
+            \ \"h2\", \"h3\", \"h4\"))))\n                                       \
+            \         .build()))\n                                    .addSum(mult(MultExpression.newBuilder()\n\
+            \                                    .addMult(constant(0.25f))\n     \
+            \                               .addMult(\n                          \
+            \              condition(\n                                          \
+            \  matchKeywords(\n                                                \"\
+            tag\",\n                                                List.of(\"p\"\
+            , \"li\"))))\n                                    .build()))\n       \
+            \                             .build()))\n                        .build()))\n\
+            \            .build())\n    .get();\n\n// Score boost geographically closer\
+            \ points (as of 1.14.0)\nclient\n    .queryAsync(\n        QueryPoints.newBuilder()\n\
+            \            .setCollectionName(\"{collection_name}\")\n            .addPrefetch(\n\
+            \                PrefetchQuery.newBuilder()\n                    .setQuery(nearest(0.01f,\
+            \ 0.45f, 0.67f))\n                    .setLimit(100)\n               \
+            \     .build())\n            .setQuery(\n                formula(\n  \
+            \                  Formula.newBuilder()\n                        .setExpression(\n\
+            \                            sum(\n                                SumExpression.newBuilder()\n\
+            \                                    .addSum(variable(\"$score\"))\n \
+            \                                   .addSum(\n                       \
+            \                 expDecay(\n                                        \
+            \    DecayParamsExpression.newBuilder()\n                            \
+            \                    .setX(\n                                        \
+            \            geoDistance(\n                                          \
+            \              GeoDistance.newBuilder()\n                            \
+            \                                .setOrigin(\n                       \
+            \                                         GeoPoint.newBuilder()\n    \
+            \                                                                .setLat(52.504043)\n\
+            \                                                                    .setLon(13.393236)\n\
+            \                                                                    .build())\n\
+            \                                                            .setTo(\"\
+            geo.location\")\n                                                    \
+            \        .build()))\n                                                .setScale(5000)\n\
+            \                                                .build()))\n        \
+            \                            .build()))\n                        .putDefaults(\n\
+            \                            \"geo.location\",\n                     \
+            \       value(\n                                Map.of(\n            \
+            \                        \"lat\", value(48.137154),\n                \
+            \                    \"lon\", value(11.576124))))\n                  \
+            \      .build()))\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc query() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t// Query nearest by ID\n\tpoints, err := client.Query(context.Background(),\
+            \ &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tQuery:          qdrant.NewQueryID(qdrant.NewID(\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\
+            )),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query\
+            \ results: \", points)\n\n\t// Recommend on the average of these vectors\n\
+            \tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\
+            \t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewID(\"\
+            43cf51e2-8777-4f52-bc74-c2cbde0c8b04\")),\n\t\t\t\tqdrant.NewVectorInput(0.11,\
+            \ 0.35, 0.6),\n\t\t\t},\n\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\
+            \tqdrant.NewVectorInput(0.01, 0.45, 0.67),\n\t\t\t},\n\t\t}),\n\t})\n\t\
+            if err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \"\
+            , points)\n\n\t// Fusion query\n\tpoints, err = client.Query(context.Background(),\
+            \ &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tPrefetch: []*qdrant.PrefetchQuery{\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuerySparse([]uint32{1,\
+            \ 42}, []float32{0.22, 0.8}),\n\t\t\t\tUsing: qdrant.PtrOf(\"sparse\"\
+            ),\n\t\t\t},\n\t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\
+            \t\t\t\tUsing: qdrant.PtrOf(\"dense\"),\n\t\t\t},\n\t\t},\n\t\tQuery:\
+            \ qdrant.NewQueryFusion(qdrant.Fusion_RRF),\n\t})\n\tif err != nil {\n\
+            \t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \", points)\n\n\t\
+            // 2-stage query\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\
+            \t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t},\n\
+            \t\t},\n\t\tQuery: qdrant.NewQueryMulti([][]float32{\n\t\t\t{0.1, 0.2},\n\
+            \t\t\t{0.2, 0.1},\n\t\t\t{0.8, 0.9},\n\t\t}),\n\t\tUsing: qdrant.PtrOf(\"\
+            colbert\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Query results: \", points)\n\n\t// Random sampling (as of 1.11.0)\n\t\
+            points, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tQuery:          qdrant.NewQuerySample(qdrant.Sample_Random),\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results:\
+            \ \", points)\n\n\t// Score boost depending on payload conditions (as\
+            \ of 1.14.0)\n\tpoints, err = client.Query(context.Background(), &qdrant.QueryPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\
+            \t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\t\t},\n\
+            \t\t},\n\t\tQuery: qdrant.NewQueryFormula(&qdrant.Formula{\n\t\t\tExpression:\
+            \ qdrant.NewExpressionSum(&qdrant.SumExpression{\n\t\t\t\tSum: []*qdrant.Expression{\n\
+            \t\t\t\t\tqdrant.NewExpressionVariable(\"$score\"),\n\t\t\t\t\tqdrant.NewExpressionMult(&qdrant.MultExpression{\n\
+            \t\t\t\t\t\tMult: []*qdrant.Expression{\n\t\t\t\t\t\t\tqdrant.NewExpressionConstant(0.5),\n\
+            \t\t\t\t\t\t\tqdrant.NewExpressionCondition(qdrant.NewMatchKeywords(\"\
+            tag\", \"h1\", \"h2\", \"h3\", \"h4\")),\n\t\t\t\t\t\t},\n\t\t\t\t\t}),\n\
+            \t\t\t\t\tqdrant.NewExpressionMult(&qdrant.MultExpression{\n\t\t\t\t\t\
+            \tMult: []*qdrant.Expression{\n\t\t\t\t\t\t\tqdrant.NewExpressionConstant(0.25),\n\
+            \t\t\t\t\t\t\tqdrant.NewExpressionCondition(qdrant.NewMatchKeywords(\"\
+            tag\", \"p\", \"li\")),\n\t\t\t\t\t\t},\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\
+            \t\t}),\n\t\t}),\n\t})\n\n\t// Score boost geographically closer points\
+            \ (as of 1.14.0)\n\tclient.Query(context.Background(), &qdrant.QueryPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tPrefetch: []*qdrant.PrefetchQuery{\n\
+            \t\t\t{\n\t\t\t\tQuery: qdrant.NewQuery(0.2, 0.8),\n\t\t\t},\n\t\t},\n\
+            \t\tQuery: qdrant.NewQueryFormula(&qdrant.Formula{\n\t\t\tExpression:\
+            \ qdrant.NewExpressionSum(&qdrant.SumExpression{\n\t\t\t\tSum: []*qdrant.Expression{\n\
+            \t\t\t\t\tqdrant.NewExpressionVariable(\"$score\"),\n\t\t\t\t\tqdrant.NewExpressionExpDecay(&qdrant.DecayParamsExpression{\n\
+            \t\t\t\t\t\tX: qdrant.NewExpressionGeoDistance(&qdrant.GeoDistance{\n\t\
+            \t\t\t\t\t\tOrigin: &qdrant.GeoPoint{\n\t\t\t\t\t\t\t\tLat: 52.504043,\n\
+            \t\t\t\t\t\t\t\tLon: 13.393236,\n\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\tTo: \"\
+            geo.location\",\n\t\t\t\t\t\t}),\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t}),\n\
+            \t\t\tDefaults: qdrant.NewValueMap(map[string]any{\n\t\t\t\t\"geo.location\"\
+            : map[string]any{\n\t\t\t\t\t\"lat\": 48.137154,\n\t\t\t\t\t\"lon\": 11.576124,\n\
+            \t\t\t\t},\n\t\t\t}),\n\t\t}),\n\t})\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Query nearest by ID\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"query\": \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\
+            \n}'\n\n# Recommend on the average of these vectors\ncurl -X POST \\\n\
+            \  'http://localhost:6333/collections/collection_name/points/query' \\\
+            \n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"query\": {\n    \"recommend\"\
+            : {\n      \"positive\": [\n        [\n          0.11,\n          0.35,\n\
+            \          0.6\n        ]\n      ],\n      \"negative\": [\n        \"\
+            43cf51e2-8777-4f52-bc74-c2cbde0c8b04\",\n        [\n          0.01,\n\
+            \          0.45,\n          0.67\n        ]\n      ]\n    }\n  }\n}'\n\
+            \n# Fusion query\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"prefetch\": [\n    {\n  \
+            \    \"query\": {\n        \"values\": [\n          0.22,\n          0.8\n\
+            \        ],\n        \"indices\": [\n          1,\n          42\n    \
+            \    ]\n      },\n      \"using\": \"sparse\",\n      \"limit\": 20\n\
+            \    },\n    {\n      \"query\": [\n        0.01,\n        0.45,\n   \
+            \     0.67\n      ],\n      \"using\": \"dense\",\n      \"limit\": 20\n\
+            \    }\n  ],\n  \"query\": {\n    \"fusion\": \"rrf\"\n  }\n}'\n\n# 2-stage\
+            \ query\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"prefetch\": {\n    \"query\"\
+            : [\n      1,\n      23,\n      45,\n      67\n    ],\n    \"limit\":\
+            \ 100\n  },\n  \"query\": [\n    [\n      0.1,\n      0.2,\n      0.3\n\
+            \    ],\n    [\n      0.2,\n      0.1,\n      0.35\n    ],\n    [\n  \
+            \    0.8,\n      0.9,\n      0.53\n    ]\n  ],\n  \"using\": \"colbert\"\
+            ,\n  \"limit\": 10\n}'\n\n# Random sampling (as of 1.11.0)\ncurl -X POST\
+            \ \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"query\": {\n    \"sample\"\
+            : \"random\"\n  }\n}'\n\n# Score boost depending on payload conditions\
+            \ (as of 1.14.0)\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n    \"prefetch\": {\n       \
+            \ \"query\": [0.2, 0.8, ...],  // <-- dense vector\n        \"limit\"\
+            : 50\n    }\n    \"query\": {\n        \"formula\": {\n            \"\
+            sum\": [\n                \"$score,\n                { \"mult\": [ 0.5,\
+            \ { \"key\": \"tag\", \"match\": { \"any\": [\"h1\", \"h2\", \"h3\", \"\
+            h4\"] } } ] },\n                { \"mult\": [ 0.25, { \"key\": \"tag\"\
+            , \"match\": { \"any\": [\"p\", \"li\"] } } ] }\n            ]\n     \
+            \   }\n    }\n}'\n\n# Score boost geographically closer points (as of\
+            \ 1.14.0)\ncurl -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n    \"prefetch\": { \"query\"\
+            : [0.2, 0.8, ...], \"limit\": 50 },\n    \"query\": {\n        \"formula\"\
+            : {\n            \"sum\": [\n                \"$score\",\n           \
+            \     {\n                    \"gauss_decay\": {\n                    \
+            \    \"x\": {\n                            \"geo_distance\": {\n     \
+            \                           \"origin\": { \"lat\": 52.504043, \"lon\"\
+            : 13.393236 } // Berlin\n                                \"to\": \"geo.location\"\
+            \n                            }\n                        },\n        \
+            \                \"scale\": 5000 // 5km\n                    }\n     \
+            \           }\n            ]\n        },\n        \"defaults\": { \"geo.location\"\
+            : {\"lat\": 48.137154, \"lon\": 11.576124} } // Munich\n    }\n}'\n"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            // Query nearest by ID\nlet _nearest = client.query(\"{collection_name\"\
+            , {\n    query: \"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\"\n});\n\n// Recommend\
+            \ on the average of these vectors\nlet _recommendations = client.query(\"\
+            {collection_name}\", {\n    query: {\n        recommend: {\n         \
+            \   positive: [\"43cf51e2-8777-4f52-bc74-c2cbde0c8b04\", [0.11, 0.35,\
+            \ 0.6]],\n            negative: [0.01, 0.45, 0.67]\n        }\n    }\n\
+            });\n\n// Fusion query\nlet _hybrid = client.query(\"{collection_name}\"\
+            , {\n    prefetch: [\n        {\n            query: {\n              \
+            \  values: [0.22, 0.8],\n                indices: [1, 42],\n         \
+            \   },\n            using: 'sparse',\n            limit: 20,\n       \
+            \ },\n        {\n            query: [0.01, 0.45, 0.67],\n            using:\
+            \ 'dense',\n            limit: 20,\n        },\n    ],\n    query: {\n\
+            \        fusion: 'rrf',\n    },\n});\n\n// 2-stage query\nlet _refined\
+            \ = client.query(\"{collection_name}\", {\n    prefetch: {\n        query:\
+            \ [1, 23, 45, 67],\n        limit: 100,\n    },\n    query: [\n      \
+            \  [0.1, 0.2],\n        [0.2, 0.1],\n        [0.8, 0.9],\n    ],\n   \
+            \ using: 'colbert',\n    limit: 10,\n});\n\n// Random sampling (as of\
+            \ 1.11.0)\nlet _sampled = client.query(\"{collection_name}\", {\n  query:\
+            \ { sample: \"random\" },\n});\n\n// Score boost depending on payload\
+            \ conditions (as of 1.14.0)\nconst tag_boosted = await client.query(\"\
+            {collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, 0.1, 0.9],\n\
+            \    limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n     \
+            \   \"$score\",\n        {\n          mult: [ 0.5, { key: \"tag\", match:\
+            \ { any: [\"h1\", \"h2\", \"h3\", \"h4\"] }} ]\n        },\n        {\n\
+            \          mult: [ 0.25, { key: \"tag\", match: { any: [\"p\", \"li\"\
+            ] }} ]\n        }\n      ]\n    }\n  }\n});\n\n// Score boost geographically\
+            \ closer points (as of 1.14.0)\nconst distance_boosted = await client.query(\"\
+            {collection_name}\", {\n  prefetch: {\n    query: [0.2, 0.8, ...],\n \
+            \   limit: 50\n  },\n  query: {\n    formula: {\n      sum: [\n      \
+            \  \"$score\",\n        {\n          gauss_decay: {\n            x: {\n\
+            \              geo_distance: {\n                origin: { lat: 52.504043,\
+            \ lon: 13.393236 }, // Berlin\n                to: \"geo.location\"\n\
+            \              }\n            },\n            scale: 5000 // 5km\n   \
+            \       }\n        }\n      ]\n    },\n    defaults: { \"geo.location\"\
+            : { lat: 48.137154, lon: 11.576124 } } // Munich\n  }\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/query/batch:
+    post:
+      description: Universally query points in batch. This endpoint covers all capabilities
+        of search, recommend, discover, filters. But also enables hybrid and multi-stage
+        queries.
+      summary: Query points in batch
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.QueryBatchAsync(\n\
+            \tcollectionName: \"{collection_name}\",\n\tqueries: new List<QueryPoints>\n\
+            \t{\n\t\tnew() { Query = new float[] { 0.1f, 0.2f, 0.3f }, },\n\t\tnew()\
+            \ { Query = new float[] { 0.4f, 0.5f, 0.6f }, }\n\t}\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nnearest = client.query_batch_points(\n   \
+            \ collection_name=\"{collection_name}\",\n    requests=[\n        models.QueryRequest(\n\
+            \            query=[0.01, 0.45, 0.67, ...],\n        ),\n        models.QueryRequest(\n\
+            \            query=[0.11, 0.35, 0.6, ...],\n        ),\n    ]\n)"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::{Qdrant, QdrantError};\nuse qdrant_client::qdrant::{Query,\
+            \ QueryPointsBuilder, QueryBatchPointsBuilder};\n\nlet request = QueryBatchPointsBuilder::new(\"\
+            {collection_name}\", vec![\n    QueryPointsBuilder::new(\"\")\n      \
+            \  .query(Query::new_nearest(\n            vec![0.1; 8],\n        )).into(),\n\
+            \    QueryPointsBuilder::new(\"\")\n        .query(Query::new_nearest(\n\
+            \            vec![0.3; 8],\n        )).into(),\n]);\n\nlet response =\
+            \ client.query_batch(request).await?;"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.QueryFactory.nearest;\n\nimport java.util.List;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            import io.qdrant.client.grpc.Points.QueryPoints;\n\nQdrantClient client\
+            \ =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334,\
+            \ false).build());\n\nclient\n    .queryBatchAsync(\n        \"{collection_name}\"\
+            ,\n        List.of(\n            QueryPoints.newBuilder().setQuery(nearest(0.1f,\
+            \ 0.2f, 0.3f)).build(),\n            QueryPoints.newBuilder().setQuery(nearest(0.4f,\
+            \ 0.5f, 0.6f)).build()))\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc queryBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(),\
+            \ &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName:\
+            \ \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.01,\
+            \ 0.45, 0.67),\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\t\t\tQuery:          qdrant.NewQuery(0.11, 0.35, 0.6),\n\t\t\t},\n\
+            \t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Query results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query/batch'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n  \
+            \    \"query\": [\n        0.23,\n        0.325,\n        0.623\n    \
+            \  ],\n      \"limit\": 1\n    },\n    {\n      \"query\": [\n       \
+            \ 0.423,\n        0.23,\n        0.623\n      ],\n      \"limit\": 5,\n\
+            \      \"using\": \"image-vector\"\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.queryBatch(\"{collection_name\", {\n    searches: [{\n        query:\
+            \ [0.01, 0.45, 0.67]\n    },\n    {\n        query: [0.11, 0.35, 0.6]\n\
+            \    }]\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/query/groups:
+    post:
+      description: Universally query points and group results by a specified payload
+        field. This endpoint covers all capabilities of search, recommend, discover,
+        filters. But also enables hybrid and multi-stage queries.
+      summary: Query point groups
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\"\
+            , 6334);\n\nawait client.QueryGroupsAsync(\n  collectionName: \"{collection_name}\"\
+            ,\n  groupBy: \"document_id\",\n  groupSize: 5,\n  limit: 10,\n  query:\
+            \ new float[] {\n    0.01f, 0.45f, 0.67f\n  }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.query_points_groups(\n    collection_name=\"\
+            {collection_name}\",\n    query=[0.01, 0.45, 0.67],\n    group_by=\"document_id\"\
+            ,\n    limit=10,\n    group_size=5,\n)"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::Qdrant;\nuse qdrant_client::qdrant::{Query, QueryPointGroupsBuilder};\n\
+            \nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\
+            \nclient.query_groups(\n    QueryPointGroupsBuilder::new(\"{collection_name}\"\
+            , \"document_id\")\n        .query(Query::from(vec![0.01, 0.45, 0.67]))\n\
+            \        .limit(10u64)\n        .group_size(5u64)\n).await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.QueryFactory.nearest;\n\
+            \nimport io.qdrant.client.grpc.Points.QueryPointGroups;\nimport io.qdrant.client.grpc.Points.QueryPoints;\n\
+            \n\nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .queryGroupsAsync(\n\
+            \        QueryPointGroups.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .setGroupBy(\"document_id\")\n     \
+            \       .setGroupSize(5)\n            .setLimit(10)\n            .setQuery(nearest(List.of(0.01f,\
+            \ 0.45f, 0.67f)))\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc queryGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tgroupSize := uint64(5)\n\tresults, err := client.QueryGroups(context.Background(),\
+            \ &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQuery:          qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\tGroupBy:\
+            \        \"document_id\",\n\t\tGroupSize:      &groupSize,\n\t})\n\tif\
+            \ err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \"\
+            , results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/query/groups'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"query\": [\n    0.324,\n\
+            \    0.643,\n    0.423\n  ],\n  \"group_by\": \"document_id\",\n  \"limit\"\
+            : 1,\n  \"group_size\": 5\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.queryGroups(\"{collection_name}\", {\n    query: [0.01, 0.45, 0.67],\n\
+            \    group_by: \"document_id\",\n    limit: 10,\n    group_size: 5,\n\
+            });\n"
+          language: typescript
+  /collections/{collection_name}/points/recommend:
+    post:
+      description: Retrieves points that are closer to stored positive examples and
+        further from negative examples.
+      summary: Recommend points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendAsync(\n\
+            \    \"{collection_name}\",\n    positive: new ulong[] { 100, 231 },\n\
+            \    negative: new ulong[] { 718 },\n    filter: MatchKeyword(\"city\"\
+            , \"London\"),\n    limit: 3\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.recommend(\n    collection_name=\"\
+            {collection_name}\",\n    positive=[100, 231],\n    negative=[718, [0.2,\
+            \ 0.3, 0.4, 0.5]],\n    strategy=models.RecommendStrategy.AVERAGE_VECTOR,\n\
+            \    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n\
+            \                key=\"city\",\n                match=models.MatchValue(\n\
+            \                    value=\"London\",\n                ),\n         \
+            \   )\n        ]\n    ),\n    limit=3,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, Filter, RecommendPointsBuilder,\
+            \ RecommendStrategy};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .recommend(\n      \
+            \  RecommendPointsBuilder::new(\"{collection_name}\", 3)\n           \
+            \ .add_positive(100)\n            .add_positive(200)\n            .add_positive(vec![100.0,\
+            \ 231.0])\n            .add_negative(718)\n            .add_negative(vec![0.2,\
+            \ 0.3, 0.4, 0.5])\n            .strategy(RecommendStrategy::AverageVector)\n\
+            \            .filter(Filter::must([Condition::matches(\n             \
+            \   \"city\",\n                \"London\".to_string(),\n            )])),\n\
+            \    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\
+            import static io.qdrant.client.PointIdFactory.id;\nimport static io.qdrant.client.VectorFactory.vector;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.RecommendPoints;\n\
+            import io.qdrant.client.grpc.Points.RecommendStrategy;\n\nQdrantClient\
+            \ client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\"\
+            , 6334, false).build());\n\nclient\n    .recommendAsync(\n        RecommendPoints.newBuilder()\n\
+            \            .setCollectionName(\"{collection_name}\")\n            .addAllPositive(List.of(id(100),\
+            \ id(200)))\n            .addAllPositiveVectors(List.of(vector(100.0f,\
+            \ 231.0f)))\n            .addAllNegative(List.of(id(718)))\n         \
+            \   .addAllPositiveVectors(List.of(vector(0.2f, 0.3f, 0.4f, 0.5f)))\n\
+            \            .setStrategy(RecommendStrategy.AverageVector)\n         \
+            \   .setFilter(Filter.newBuilder().addMust(matchKeyword(\"city\", \"London\"\
+            )))\n            .setLimit(3)\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc recommend() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.Query(context.Background(),\
+            \ &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\tPositive:\
+            \ []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t},\n\t\t\
+            \tNegative: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\
+            \t\t\t\tqdrant.NewVectorInput(0.2, 0.3, 0.4, 0.5),\n\t\t\t},\n\t\t\tStrategy:\
+            \ qdrant.RecommendStrategy_AverageVector.Enum(),\n\t\t}),\n\t\tFilter:\
+            \ &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"\
+            city\", \"London\"),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\t\
+            panic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"positive\": [\n    100,\n\
+            \    231\n  ],\n  \"negative\": [\n    \"3a6e2150-f7b7-496e-92cd-687e63e215fd\"\
+            ,\n    [\n      0.2,\n      0.3,\n      0.4,\n      0.5\n    ]\n  ],\n\
+            \  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"city\"\
+            ,\n        \"match\": {\n          \"value\": \"London\"\n        }\n\
+            \      }\n    ]\n  },\n  \"limit\": 1\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.recommend(\"{collection_name}\", {\n    positive: [100, 231],\n\
+            \    negative: [718, [0.2, 0.3, 0.4, 0.5]],\n    strategy: \"average_vector\"\
+            ,\n    filter: {\n        must: [\n            {\n                key:\
+            \ \"city\",\n                match: {\n                    value: \"London\"\
+            ,\n                },\n            },\n        ],\n    },\n    limit:\
+            \ 3,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/recommend/batch:
+    post:
+      description: Retrieves points in batches that are closer to stored positive
+        examples and further from negative examples.
+      summary: Recommend batch points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter =\
+            \ MatchKeyword(\"city\", \"london\");\n\nawait client.RecommendBatchAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  recommendSearches:\n  [\n\
+            \    new()\n    {\n      CollectionName = \"{collection_name}\",\n   \
+            \   Positive = { new PointId[] { 100, 231 } },\n      Negative = { new\
+            \ PointId[] { 718 } },\n      Limit = 3,\n      Filter = filter,\n   \
+            \ },\n    new()\n    {\n      CollectionName = \"{collection_name}\",\n\
+            \      Positive = { new PointId[] { 200, 67 } },\n      Negative = { new\
+            \ PointId[] { 300 } },\n      Limit = 3,\n      Filter = filter,\n   \
+            \ }\n  ]\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nrecommend_queries = [\n    models.RecommendRequest(\n\
+            \        positive=[100, 231], negative=[718], filter=filter_, limit=3\n\
+            \    ),\n    models.RecommendRequest(positive=[200, 67], negative=[300],\
+            \ limit=3),\n]\n\nclient.recommend_batch(collection_name=\"{collection_name}\"\
+            , requests=recommend_queries)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    Condition, Filter, RecommendBatchPointsBuilder,\
+            \ RecommendPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client\
+            \ = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter\
+            \ = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\n\
+            let recommend_queries = vec![\n    RecommendPointsBuilder::new(\"{collection_name}\"\
+            , 3)\n        .add_positive(100)\n        .add_positive(231)\n       \
+            \ .add_negative(718)\n        .filter(filter.clone())\n        .build(),\n\
+            \    RecommendPointsBuilder::new(\"{collection_name}\", 3)\n        .add_positive(200)\n\
+            \        .add_positive(67)\n        .add_negative(300)\n        .filter(filter.clone())\n\
+            \        .build(),\n];\n\nclient\n    .recommend_batch(RecommendBatchPointsBuilder::new(\n\
+            \        \"{collection_name}\",\n        recommend_queries,\n    ))\n\
+            \    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\
+            import static io.qdrant.client.PointIdFactory.id;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Common.Filter;\n\
+            import io.qdrant.client.grpc.Points.RecommendPoints;\n\nQdrantClient client\
+            \ =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"localhost\", 6334,\
+            \ false).build());\n\nFilter filter = Filter.newBuilder().addMust(matchKeyword(\"\
+            city\", \"London\")).build();\n\nList<RecommendPoints> recommendQueries\
+            \ =\n    List.of(\n        RecommendPoints.newBuilder()\n            .addAllPositive(List.of(id(100),\
+            \ id(231)))\n            .addAllNegative(List.of(id(718)))\n         \
+            \   .setFilter(filter)\n            .setLimit(3)\n            .build(),\n\
+            \        RecommendPoints.newBuilder()\n            .addAllPositive(List.of(id(200),\
+            \ id(67)))\n            .addAllNegative(List.of(id(300)))\n          \
+            \  .setFilter(filter)\n            .setLimit(3)\n            .build());\n\
+            \nclient.recommendBatchAsync(\"{collection_name}\", recommendQueries,\
+            \ null).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc recommendBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tresults, err := client.QueryBatch(context.Background(),\
+            \ &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName:\
+            \ \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\
+            \t\t\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t\t\t\
+            },\n\t\t\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\
+            \t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName:\
+            \ \"{collection_name}\",\n\t\t\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\
+            \t\t\t\t\tPositive: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(200)),\n\
+            \t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(67)),\n\t\t\t\t\t\
+            },\n\t\t\t\t\tNegative: []*qdrant.VectorInput{\n\t\t\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(300)),\n\
+            \t\t\t\t\t},\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\
+            \t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend/batch'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n  \
+            \    \"positive\": [\n        100,\n        231\n      ],\n      \"negative\"\
+            : [\n        \"9ad0884a-7bfe-43c0-b88f-c1d9a588b7e1\"\n      ],\n    \
+            \  \"limit\": 1\n    },\n    {\n      \"positive\": [\n        200,\n\
+            \        67\n      ],\n      \"negative\": [\n        300\n      ],\n\
+            \      \"limit\": 5\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            const searches = [\n    {\n        positive: [100, 231],\n        negative:\
+            \ [718],\n        limit: 3,\n    },\n    {\n        positive: [200, 67],\n\
+            \        negative: [300],\n        limit: 3,\n    },\n];\n\nclient.recommend_batch(\"\
+            {collection_name}\", {\n    searches,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/recommend/groups:
+    post:
+      description: Retrieves points that are closer to stored positive examples and
+        further from negative examples. Results are grouped by the specified payload
+        field.
+      summary: Recommend point groups
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.RecommendGroupsAsync(\n\
+            \    \"{collection_name}\",\n    \"document_id\",\n    groupSize: 3,\n\
+            \    positive: new ulong[] { 100, 231 },\n    negative: new ulong[] {\
+            \ 718 },\n    filter: MatchKeyword(\"city\", \"London\"),\n    limit:\
+            \ 3\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.recommend_groups(\n    collection_name=\"\
+            {collection_name}\",\n    positive=[100, 231],\n    negative=[718],\n\
+            \    group_by=\"document_id\",\n    limit=3,\n    group_size=2,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{RecommendPointGroupsBuilder, RecommendStrategy};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .recommend_groups(\n        RecommendPointGroupsBuilder::new(\"\
+            {collection_name}\", \"document_id\", 2, 3)\n            .add_positive(100)\n\
+            \            .add_positive(200)\n            .add_negative(718)\n    \
+            \        .strategy(RecommendStrategy::AverageVector),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Points.RecommendPointGroups;\nimport io.qdrant.client.grpc.Points.RecommendStrategy;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.recommendGroupsAsync(RecommendPointGroups.newBuilder()\n\
+            \                .setCollectionName(\"{collection_name}\")\n         \
+            \       .setGroupBy(\"document_id\")\n                .setGroupSize(2)\n\
+            \                .addAllPositive(List.of(id(100), id(200)))\n        \
+            \        .addAllNegative(List.of(id(718)))\n                .setStrategy(RecommendStrategy.AverageVector)\n\
+            \                .setLimit(3)\n                .build());\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc recommendGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tgroupSize := uint64(5)\n\tresults, err := client.QueryGroups(context.Background(),\
+            \ &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQuery: qdrant.NewQueryRecommend(&qdrant.RecommendInput{\n\t\t\t\
+            Positive: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(100)),\n\
+            \t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(231)),\n\t\t\t},\n\t\t\
+            \tNegative: []*qdrant.VectorInput{\n\t\t\t\tqdrant.NewVectorInputID(qdrant.NewIDNum(718)),\n\
+            \t\t\t},\n\t\t}),\n\t\tGroupBy:   \"document_id\",\n\t\tGroupSize: &groupSize,\n\
+            \t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results:\
+            \ \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/recommend/groups'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"positive\": [\n    100,\n\
+            \    231\n  ],\n  \"negative\": [\n    718\n  ],\n  \"group_by\": \"document_id\"\
+            ,\n  \"limit\": 3,\n  \"group_size\": 2\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.recommendPointGroups(\"{collection_name}\", {\n    positive: [100,\
+            \ 231],\n    negative: [718],\n    group_by: \"document_id\",\n    limit:\
+            \ 3,\n    group_size: 2,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/scroll:
+    post:
+      description: 'Returns all points in a page-by-page manner.
+
+        By default, all resulting points are sorted by {id}.
+
+        To query the next page specify the last {id} in the offset field.
+
+        Additionally, you can specify filters and sorting options.
+
+        '
+      summary: Scroll points
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.ScrollAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  filter: MatchKeyword(\"color\"\
+            , \"red\"),\n  limit: 1,\n  payloadSelector: true\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.scroll(\n    collection_name=\"{collection_name}\"\
+            ,\n    scroll_filter=models.Filter(\n        must=[\n            models.FieldCondition(key=\"\
+            color\", match=models.MatchValue(value=\"red\")),\n        ]\n    ),\n\
+            \    limit=1,\n    with_payload=True,\n    with_vectors=False,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .scroll(\n        ScrollPointsBuilder::new(\"\
+            {collection_name}\")\n            .filter(Filter::must([Condition::matches(\n\
+            \                \"color\",\n                \"red\".to_string(),\n  \
+            \          )]))\n            .limit(1)\n            .with_payload(true)\n\
+            \            .with_vectors(false),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\nimport\
+            \ static io.qdrant.client.WithPayloadSelectorFactory.enable;\n\nimport\
+            \ io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.ScrollPoints;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .scrollAsync(\n   \
+            \     ScrollPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\"\
+            )\n            .setFilter(Filter.newBuilder().addMust(matchKeyword(\"\
+            color\", \"red\")).build())\n            .setLimit(1)\n            .setWithPayload(enable(true))\n\
+            \            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc scroll() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tlimit := uint32(1)\n\tresults, err := client.Scroll(context.Background(),\
+            \ &qdrant.ScrollPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tFilter: &qdrant.Filter{\n\t\t\tMust: []*qdrant.Condition{\n\t\t\t\t\
+            qdrant.NewMatch(\"color\", \"red\"),\n\t\t\t},\n\t\t},\n\t\tLimit:   \
+            \    &limit,\n\t\tWithPayload: qdrant.NewWithPayloadEnable(true),\n\t\t\
+            WithVectors: qdrant.NewWithVectorsEnable(false),\n\t})\n\tif err != nil\
+            \ {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/scroll'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"with_payload\": [\n    \"\
+            city\",\n    \"color\"\n  ],\n  \"filter\": {\n    \"must\": [\n     \
+            \ {\n        \"key\": \"color\",\n        \"match\": {\n          \"value\"\
+            : \"red\"\n        }\n      }\n    ]\n  },\n  \"limit\": 2,\n  \"with_vector\"\
+            : false\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.scroll(\"{collection_name}\", {\n    filter: {\n        must: [\n\
+            \            {\n                key: \"color\",\n                match:\
+            \ {\n                    value: \"red\",\n                },\n       \
+            \     },\n        ],\n    },\n    limit: 1,\n    with_payload: true,\n\
+            \    with_vector: false,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/search:
+    post:
+      description: Retrieves the closest points based on vector similarity and given
+        filtering conditions.
+      summary: Search points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nawait client.SearchAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  vector: new float[] { 0.2f,\
+            \ 0.1f, 0.9f, 0.7f },\n  filter: MatchKeyword(\"city\", \"London\"),\n\
+            \  limit: 3\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.search(\n    collection_name=\"{collection_name}\"\
+            ,\n    query_filter=models.Filter(\n        must=[\n            models.FieldCondition(\n\
+            \                key=\"city\",\n                match=models.MatchValue(\n\
+            \                    value=\"London\",\n                ),\n         \
+            \   )\n        ]\n    ),\n    query_vector=[0.2, 0.1, 0.9, 0.7],\n   \
+            \ limit=3,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, Filter, SearchParamsBuilder,\
+            \ SearchPointsBuilder};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .search_points(\n  \
+            \      SearchPointsBuilder::new(\"{collection_name}\", vec![0.2, 0.1,\
+            \ 0.9, 0.7], 3)\n            .filter(Filter::must([Condition::matches(\n\
+            \                \"city\",\n                \"London\".to_string(),\n\
+            \            )]))\n            .params(SearchParamsBuilder::default().hnsw_ef(128).exact(false)),\n\
+            \    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\n\
+            import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchPoints;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .searchAsync(\n   \
+            \     SearchPoints.newBuilder()\n            .setCollectionName(\"{collection_name}\"\
+            )\n            .setFilter(Filter.newBuilder().addMust(matchKeyword(\"\
+            city\", \"London\")).build())\n            .addAllVector(List.of(0.2f,\
+            \ 0.1f, 0.9f, 0.7f))\n            .setLimit(3)\n            .build())\n\
+            \    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc search() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tlimit := uint64(3)\n\tresults, err := client.Query(context.Background(),\
+            \ &qdrant.QueryPoints{\n\t\tCollectionName: \"{collection_name}\",\n\t\
+            \tQuery:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),\n\t\tFilter: &qdrant.Filter{\n\
+            \t\t\tMust: []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"city\", \"\
+            London\"),\n\t\t\t},\n\t\t},\n\t\tLimit: &limit,\n\t})\n\tif err != nil\
+            \ {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"vector\": [\n    0.2,\n \
+            \   0.1,\n    0.9,\n    0.7\n  ],\n  \"limit\": 1,\n  \"filter\": {\n\
+            \    \"must\": [\n      {\n        \"key\": \"city\",\n        \"match\"\
+            : {\n          \"value\": \"London\"\n        }\n      }\n    ]\n  }\n\
+            }'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.search(\"{collection_name}\", {\n    filter: {\n        must: [\n\
+            \            {\n                key: \"city\",\n                match:\
+            \ {\n                    value: \"London\",\n                },\n    \
+            \        },\n        ],\n    },\n    vector: [0.2, 0.1, 0.9, 0.7],\n \
+            \   limit: 3,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/search/batch:
+    post:
+      description: Retrieves the closest points in batches based on vector similarity
+        and given filtering conditions.
+      summary: Search batch points
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\nusing static Qdrant.Client.Grpc.Conditions;\n\
+            \nvar client = new QdrantClient(\"localhost\", 6334);\n\nvar filter =\
+            \ MatchKeyword(\"city\", \"London\");\n\nvar searches = new List<SearchPoints>\n\
+            {\n  new()\n  {\n    Vector = { new float[] { 0.2f, 0.1f, 0.9f, 0.7f }\
+            \ },\n    Filter = filter,\n    Limit = 3\n  },\n  new()\n  {\n    Vector\
+            \ = { new float[] { 0.5f, 0.3f, 0.2f, 0.3f } },\n    Filter = filter,\n\
+            \    Limit = 3\n  }\n};\n\nawait client.SearchBatchAsync(collectionName:\
+            \ \"{collection_name}\", searches: searches);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nfilter_ = models.Filter(\n    must=[\n   \
+            \     models.FieldCondition(\n            key=\"city\",\n            match=models.MatchValue(\n\
+            \                value=\"London\",\n            ),\n        )\n    ]\n\
+            )\n\nsearch_queries = [\n    models.SearchRequest(vector=[0.2, 0.1, 0.9,\
+            \ 0.7], filter=filter_, limit=3),\n    models.SearchRequest(vector=[0.5,\
+            \ 0.3, 0.2, 0.3], filter=filter_, limit=3),\n]\n\nclient.search_batch(collection_name=\"\
+            {collection_name}\", requests=search_queries)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{\n    Condition, Filter, SearchBatchPointsBuilder,\
+            \ SearchPointsBuilder,\n};\nuse qdrant_client::Qdrant;\n\nlet client =\
+            \ Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nlet filter\
+            \ = Filter::must([Condition::matches(\"city\", \"London\".to_string())]);\n\
+            \nlet searches = vec![\n    SearchPointsBuilder::new(\"{collection_name}\"\
+            , vec![0.2, 0.1, 0.9, 0.7], 3)\n        .filter(filter.clone())\n    \
+            \    .build(),\n    SearchPointsBuilder::new(\"{collection_name}\", vec![0.5,\
+            \ 0.3, 0.2, 0.3], 3)\n        .filter(filter.clone())\n        .build(),\n\
+            ];\n\nclient\n    .search_batch_points(SearchBatchPointsBuilder::new(\"\
+            {collection_name}\", searches))\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport static io.qdrant.client.ConditionFactory.matchKeyword;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchPoints;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nFilter filter = Filter.newBuilder().addMust(matchKeyword(\"\
+            city\", \"London\")).build();\nList<SearchPoints> searches =\n    List.of(\n\
+            \        SearchPoints.newBuilder()\n            .addAllVector(List.of(0.2f,\
+            \ 0.1f, 0.9f, 0.7f))\n            .setFilter(filter)\n            .setLimit(3)\n\
+            \            .build(),\n        SearchPoints.newBuilder()\n          \
+            \  .addAllVector(List.of(0.5f, 0.3f, 0.2f, 0.3f))\n            .setFilter(filter)\n\
+            \            .setLimit(3)\n            .build());\nclient.searchBatchAsync(\"\
+            {collection_name}\", searches, null).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc searchBatch() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tfilter := qdrant.Filter{\n\t\tMust: []*qdrant.Condition{\n\
+            \t\t\tqdrant.NewMatch(\"city\", \"London\"),\n\t\t},\n\t}\n\tlimit :=\
+            \ uint64(3)\n\tresults, err := client.QueryBatch(context.Background(),\
+            \ &qdrant.QueryBatchPoints{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQueryPoints: []*qdrant.QueryPoints{\n\t\t\t{\n\t\t\t\tCollectionName:\
+            \ \"{collection_name}\",\n\t\t\t\tQuery:          qdrant.NewQuery(0.2,\
+            \ 0.1, 0.9, 0.7),\n\t\t\t\tLimit:          &limit,\n\t\t\t\tFilter:  \
+            \       &filter,\n\t\t\t},\n\t\t\t{\n\t\t\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\t\t\tQuery:          qdrant.NewQuery(0.5, 0.3, 0.2, 0.3),\n\t\t\t\
+            \tLimit:          &limit,\n\t\t\t\tFilter:         &filter,\n\t\t\t},\n\
+            \t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Query results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search/batch'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"searches\": [\n    {\n  \
+            \    \"vector\": [\n        0.2,\n        0.1,\n        0.9,\n       \
+            \ 0.7\n      ],\n      \"limit\": 3\n    },\n    {\n      \"vector\":\
+            \ [\n        0.5,\n        0.3,\n        0.2,\n        0.3\n      ],\n\
+            \      \"filter\": {\n        \"must\": [\n          {\n            \"\
+            key\": \"city\",\n            \"match\": {\n              \"value\": \"\
+            London\"\n            }\n          }\n        ]\n      },\n      \"limit\"\
+            : 3\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            const filter = {\n    must: [\n        {\n            key: \"city\",\n\
+            \            match: {\n                value: \"London\",\n          \
+            \  },\n        },\n    ],\n};\n\nconst searches = [\n    {\n        vector:\
+            \ [0.2, 0.1, 0.9, 0.7],\n        filter,\n        limit: 3,\n    },\n\
+            \    {\n        vector: [0.5, 0.3, 0.2, 0.3],\n        filter,\n     \
+            \   limit: 3,\n    },\n];\n\nclient.searchBatch(\"{collection_name}\"\
+            , {\n    searches,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/search/groups:
+    post:
+      description: Retrieves the closest points based on vector similarity and given
+        filtering conditions, grouped by a given payload field.
+      summary: Search point groups
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\n\nvar client = new QdrantClient(\"localhost\"\
+            , 6334);\n\nawait client.SearchGroupsAsync(\n  collectionName: \"{collection_name}\"\
+            ,\n  vector: new float[] { 1.1f },\n  groupBy: \"document_id\",\n  limit:\
+            \ 4,\n  groupSize: 2\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.search_groups(\n    collection_name=\"\
+            {collection_name}\",\n    query_vector=[1.1],\n    group_by=\"document_id\"\
+            ,\n    limit=4,\n    group_size=2,\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::SearchPointGroupsBuilder;\nuse qdrant_client::Qdrant;\n\
+            \nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\
+            \nclient\n    .search_groups(SearchPointGroupsBuilder::new(\n        \"\
+            {collection_name}\",\n        vec![1.1],\n        4,\n        \"document_id\"\
+            ,\n        2,\n    ))\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import java.util.List;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nimport io.qdrant.client.grpc.Points.SearchPointGroups;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .searchGroupsAsync(\n\
+            \        SearchPointGroups.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .addAllVector(List.of(1.1f))\n     \
+            \       .setGroupBy(\"document_id\")\n            .setLimit(4)\n     \
+            \       .setGroupSize(2)\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc searchGroups() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tgroupSize := uint64(2)\n\tresults, err := client.QueryGroups(context.Background(),\
+            \ &qdrant.QueryPointGroups{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tQuery:          qdrant.NewQuery(0.01, 0.45, 0.67),\n\t\tGroupBy:\
+            \        \"document_id\",\n\t\tGroupSize:      &groupSize,\n\t})\n\tif\
+            \ err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Query results: \"\
+            , results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/search/groups'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"vector\": [\n    0.2,\n \
+            \   0.1,\n    0.9,\n    0.7\n  ],\n  \"group_by\": \"document_id\",\n\
+            \  \"limit\": 4,\n  \"group_size\": 2\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.searchPointGroups(\"{collection_name}\", {\n    vector: [1.1],\n\
+            \    group_by: \"document_id\",\n    limit: 4,\n    group_size: 2,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/search/matrix/offsets:
+    post:
+      description: Retrieves sparse matrix of pairwise distances between points sampled
+        from the collection. Output is a form of row and column offsets and list of
+        distances.
+      summary: Distance matrix offsets
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixOffsetsAsync(\n\
+            \    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"\
+            ),\n    sample: 100,\n    limit: 5\n);"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.search_matrix_offsets(\n    collection_name=\"\
+            {collection_name}\",\n    sample=100,\n    limit=5,\n    query_filter=models.Filter(\n\
+            \        must=[\n            models.FieldCondition(\n                key=\"\
+            color\", match=models.MatchValue(value=\"red\")\n            ),\n    \
+            \    ]\n    ),\n)"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder,\
+            \ Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_offsets(\n\
+            \        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n     \
+            \      .filter(Filter::must(vec![Condition::matches(\n               \"\
+            color\",\n               \"red\".to_string(),\n           )]))\n     \
+            \      .sample(100)\n           .limit(5),\n    )\n    .await?;"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\n\
+            import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            import io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchMatrixPoints;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .searchMatrixOffsetsAsync(\n\
+            \        SearchMatrixPoints.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .setFilter(\n                Filter.newBuilder()\n\
+            \                    .addMust(matchKeyword(\"color\", \"red\"))\n    \
+            \                .build()\n            )\n            .setSample(100)\n\
+            \            .setLimit(5)\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc searchMatiOffsets() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsample := uint64(100)\n\tlimit := uint64(5)\n\t\
+            results, err := client.SearchMatrixOffsets(context.Background(), &qdrant.SearchMatrixPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tSample:         &sample,\n\
+            \t\tLimit:          &limit,\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust:\
+            \ []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\
+            \t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Query results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.searchMatrixOffsets(\"{collection_name}\", {\n    filter: {\n \
+            \       must: [\n            {\n                key: \"color\",\n    \
+            \            match: {\n                    value: \"red\",\n         \
+            \       },\n            },\n        ],\n    },\n    sample: 100,\n   \
+            \ limit: 5,\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/search/matrix/pairs:
+    post:
+      description: Retrieves sparse matrix of pairwise distances between points sampled
+        from the collection. Output is a list of pairs of points and their distances.
+      summary: Distance matrix pairs
+      tags:
+      - Search
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.SearchMatrixPairsAsync(\n\
+            \    \"{collection_name}\",\n    filter: MatchKeyword(\"color\", \"red\"\
+            ),\n    sample: 100,\n    limit: 5\n);"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.search_matrix_pairs(\n    collection_name=\"\
+            {collection_name}\",\n    sample=100,\n    limit=5,\n    query_filter=models.Filter(\n\
+            \        must=[\n            models.FieldCondition(\n                key=\"\
+            color\", match=models.MatchValue(value=\"red\")\n            ),\n    \
+            \    ]\n    ),\n)"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{Condition, SearchMatrixPointsBuilder,\
+            \ Filter};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .search_matrix_pairs(\n\
+            \        SearchMatrixPointsBuilder::new(\"{collection_name}\")\n     \
+            \      .filter(Filter::must(vec![Condition::matches(\n               \"\
+            color\",\n               \"red\".to_string(),\n           )]))\n     \
+            \      .sample(100)\n           .limit(5),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ConditionFactory.matchKeyword;\n\n\
+            import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            import io.qdrant.client.grpc.Common.Filter;\nimport io.qdrant.client.grpc.Points.SearchMatrixPoints;\n\
+            \nQdrantClient client =\n    new QdrantClient(QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .searchMatrixPairsAsync(\n\
+            \        SearchMatrixPoints.newBuilder()\n            .setCollectionName(\"\
+            {collection_name}\")\n            .setFilter(\n                Filter.newBuilder()\n\
+            \                    .addMust(matchKeyword(\"color\", \"red\"))\n    \
+            \                .build()\n            )\n            .setSample(100)\n\
+            \            .setLimit(5)\n            .build())\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc searchMatixPairs() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsample := uint64(100)\n\tlimit := uint64(5)\n\t\
+            results, err := client.SearchMatrixPairs(context.Background(), &qdrant.SearchMatrixPoints{\n\
+            \t\tCollectionName: \"{collection_name}\",\n\t\tSample:         &sample,\n\
+            \t\tLimit:          &limit,\n\t\tFilter: &qdrant.Filter{\n\t\t\tMust:\
+            \ []*qdrant.Condition{\n\t\t\t\tqdrant.NewMatch(\"color\", \"red\"),\n\
+            \t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Query results: \", results)\n}\n"
+          language: go
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.searchMatrixPairs(\"{collection_name}\", {\n    filter: {\n   \
+            \     must: [\n            {\n                key: \"color\",\n      \
+            \          match: {\n                    value: \"red\",\n           \
+            \     },\n            },\n        ],\n    },\n    sample: 100,\n    limit:\
+            \ 5,\n});"
+          language: typescript
+  /collections/{collection_name}/points/vectors:
+    put:
+      description: Updates specified vectors on points. All other unspecified vectors
+        will stay intact.
+      summary: Update vectors
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.UpdateVectorsAsync(\n\
+            \  collectionName: \"{collection_name}\",\n  points: new List<PointVectors>\n\
+            \  {\n    new() { Id = 1, Vectors = (\"image\", new float[] { 0.1f, 0.2f,\
+            \ 0.3f, 0.4f }) },\n    new()\n    {\n      Id = 2,\n      Vectors = (\"\
+            text\", new float[] { 0.9f, 0.8f, 0.7f, 0.6f, 0.5f, 0.4f, 0.3f, 0.2f })\n\
+            \    }\n  }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient, models\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.update_vectors(\n    collection_name=\"\
+            {collection_name}\",\n    points=[\n        models.PointVectors(\n   \
+            \         id=1,\n            vector={\n                \"image\": [0.1,\
+            \ 0.2, 0.3, 0.4],\n            },\n        ),\n        models.PointVectors(\n\
+            \            id=2,\n            vector={\n                \"text\": [0.9,\
+            \ 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n            },\n        ),\n  \
+            \  ],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{PointVectors, UpdatePointVectorsBuilder};\n\
+            use qdrant_client::Qdrant;\nuse std::collections::HashMap;\n\nlet client\
+            \ = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n\
+            \    .update_vectors(\n        UpdatePointVectorsBuilder::new(\n     \
+            \       \"{collection_name}\",\n            vec![\n                PointVectors\
+            \ {\n                    id: Some(1.into()),\n                    vectors:\
+            \ Some(\n                        HashMap::from([(\"image\".to_string(),\
+            \ vec![0.1, 0.2, 0.3, 0.4])])\n                            .into(),\n\
+            \                    ),\n                },\n                PointVectors\
+            \ {\n                    id: Some(2.into()),\n                    vectors:\
+            \ Some(\n                        HashMap::from([(\n                  \
+            \          \"text\".to_string(),\n                            vec![0.9,\
+            \ 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n                        )])\n \
+            \                       .into(),\n                    ),\n           \
+            \     },\n            ],\n        )\n        .wait(true),\n    )\n   \
+            \ .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\nimport static\
+            \ io.qdrant.client.VectorFactory.vector;\nimport static io.qdrant.client.VectorsFactory.namedVectors;\n\
+            \nimport java.util.List;\nimport java.util.Map;\n\nimport io.qdrant.client.QdrantClient;\n\
+            import io.qdrant.client.QdrantGrpcClient;\n\nQdrantClient client = new\
+            \ QdrantClient(\n                QdrantGrpcClient.newBuilder(\"localhost\"\
+            , 6334, false).build());\n\nclient\n    .updateVectorsAsync(\n       \
+            \ \"{collection_name}\",\n        List.of(\n            PointVectors.newBuilder()\n\
+            \                .setId(id(1))\n                .setVectors(namedVectors(Map.of(\"\
+            image\", vector(List.of(0.1f, 0.2f, 0.3f, 0.4f)))))\n                .build(),\n\
+            \            PointVectors.newBuilder()\n                .setId(id(2))\n\
+            \                .setVectors(\n                    namedVectors(\n   \
+            \                     Map.of(\n                            \"text\", vector(List.of(0.9f,\
+            \ 0.8f, 0.7f, 0.6f, 0.5f, 0.4f, 0.3f, 0.2f)))))\n                .build()))\n\
+            \    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc updateVectors() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.UpdateVectors(context.Background(),\
+            \ &qdrant.UpdatePointVectors{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPoints: []*qdrant.PointVectors{\n\t\t\t{\n\t\t\t\tId: qdrant.NewIDNum(1),\n\
+            \t\t\t\tVectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{\n\t\t\
+            \t\t\t\"image\": qdrant.NewVector(0.1, 0.2, 0.3, 0.4),\n\t\t\t\t}),\n\t\
+            \t\t},\n\t\t\t{\n\t\t\t\tId: qdrant.NewIDNum(2),\n\t\t\t\tVectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{\n\
+            \t\t\t\t\t\"text\": qdrant.NewVector(0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3,\
+            \ 0.2),\n\t\t\t\t}),\n\t\t\t},\n\t\t},\n\t})\n\tif err != nil {\n\t\t\
+            panic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/points/vectors?wait=true'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"points\": [\n    {\n    \
+            \  \"id\": 1,\n      \"vector\": [\n        0.0984,\n        0.1406,\n\
+            \        0.8973\n      ]\n    },\n    {\n      \"id\": 2,\n      \"vector\"\
+            : {\n        \"vector-name\": [\n          0.9,\n          0.8,\n    \
+            \      0.7,\n          0.6\n        ]\n      }\n    }\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.updateVectors(\"{collection_name}\", {\n    points: [\n       \
+            \ {\n            id: 1,\n            vector: {\n                image:\
+            \ [0.1, 0.2, 0.3, 0.4],\n            },\n        },\n        {\n     \
+            \       id: 2,\n            vector: {\n                text: [0.9, 0.8,\
+            \ 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],\n            },\n        },\n    ],\n\
+            });\n"
+          language: typescript
+  /collections/{collection_name}/points/vectors/delete:
+    post:
+      description: Deletes specified vectors from points. All other unspecified vectors
+        will stay intact.
+      summary: Delete vectors
+      tags:
+      - Points
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeleteVectorsAsync("{collection_name}", ["text", "image"],
+            [0, 3, 10]);
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.delete_vectors(\n    collection_name=\"\
+            {collection_name}\",\n    points=[0, 3, 100],\n    vectors=[\"text\",\
+            \ \"image\"],\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::{DeletePointVectorsBuilder, PointsIdsList,\
+            \ VectorsSelector};\nuse qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"\
+            http://localhost:6334\").build()?;\n\nclient\n    .delete_vectors(\n \
+            \       DeletePointVectorsBuilder::new(\"{collection_name}\")\n      \
+            \      .points_selector(PointsIdsList {\n                ids: vec![0.into(),\
+            \ 3.into(), 10.into()],\n            })\n            .vectors(VectorsSelector\
+            \ {\n                names: vec![\"text\".into(), \"image\".into()],\n\
+            \            })\n            .wait(true),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.PointIdFactory.id;\n\nimport java.util.List;\n\
+            \nimport io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient\n    .deleteVectorsAsync(\n\
+            \        \"{collection_name}\", List.of(\"text\", \"image\"), List.of(id(0),\
+            \ id(3), id(10)))\n    .get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteVectors() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\t_, err = client.DeleteVectors(context.Background(),\
+            \ &qdrant.DeletePointVectors{\n\t\tCollectionName: \"{collection_name}\"\
+            ,\n\t\tPointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(0), qdrant.NewIDNum(3),\
+            \ qdrant.NewIDNum(100)),\n\t\tVectors: &qdrant.VectorsSelector{\n\t\t\t\
+            Names: []string{\"text\", \"image\"},\n\t\t},\n\t})\n\tif err != nil {\n\
+            \t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "# Delete vectors by ID\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/vectors/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"points\": [\n    0,\n   \
+            \ 3,\n    10\n  ],\n  \"vectors\": [\n    \"text\",\n    \"image\"\n \
+            \ ]\n}'\n\n# Delete vectors by filter\ncurl  -X POST \\\n  'http://localhost:6333/collections/collection_name/points/vectors/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"filter\": {\n    \"must\"\
+            : [\n      {\n        \"key\": \"color\",\n        \"match\": {\n    \
+            \      \"value\": \"red\"\n        }\n      }\n    ]\n  },\n  \"vectors\"\
+            : [\n    \"text\",\n    \"image\"\n  ]\n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.deleteVectors(\"{collection_name}\", {\n  points: [0, 3, 10],\n\
+            \  vectors: [\"text\", \"image\"],\n});\n"
+          language: typescript
+  /collections/{collection_name}/points/{id}:
+    get:
+      description: Retrieves all details from a single point.
+      summary: Retrieve a point
+      tags:
+      - Points
+  /collections/{collection_name}/shards:
+    put:
+      description: Creates one or more shard keys for a specified collection.
+      summary: Create a shard key
+      tags:
+      - Distributed
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.CreateShardKeyAsync(\n\
+            \    \"{collection_name}\",\n    new CreateShardKey { ShardKey = new ShardKey\
+            \ { Keyword = \"{shard_key}\", } }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.create_shard_key("{collection_name}", "{shard_key}")
+
+            '
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::{CreateShardKeyBuilder,\
+            \ CreateShardKeyRequestBuilder};\nuse qdrant_client::Qdrant;\n\nlet client\
+            \ = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\nclient\n\
+            \    .create_shard_key(\n        CreateShardKeyRequestBuilder::new(\"\
+            {collection_name}\").request(\n            CreateShardKeyBuilder::default()\n\
+            \                .shard_key(Key::Keyword(\"{shard_key}\".to_string())),\n\
+            \        ),\n    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport\
+            \ io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.CreateShardKey;\nimport io.qdrant.client.grpc.Collections.CreateShardKeyRequest;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createShardKeyAsync(CreateShardKeyRequest.newBuilder()\n\
+            \                .setCollectionName(\"{collection_name}\")\n         \
+            \       .setRequest(CreateShardKey.newBuilder()\n                    \
+            \            .setShardKey(shardKey(\"{shard_key}\"))\n               \
+            \                 .build())\n                .build()).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc createShardKey() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.CreateShardKey(context.Background(),\
+            \ \"{collection_name}\", &qdrant.CreateShardKey{\n\t\tShardKey: qdrant.NewShardKey(\"\
+            {shard_key}\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/shards'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"shard_key\": \"{shard_key}\"\
+            \n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n\
+            });\n\nclient.createShardKey(\"{collection_name}\", {\n    shard_key:\
+            \ \"{shard_key}\"\n});\n"
+          language: typescript
+  /collections/{collection_name}/shards/delete:
+    post:
+      description: Deletes one or more shard keys for a specified collection.
+      summary: Delete a shard key
+      tags:
+      - Distributed
+      x-fern-examples:
+      - code-samples:
+        - code: "using Qdrant.Client;\nusing Qdrant.Client.Grpc;\n\nvar client = new\
+            \ QdrantClient(\"localhost\", 6334);\n\nawait client.DeleteShardKeyAsync(\n\
+            \    \"{collection_name}\",\n    new DeleteShardKey { ShardKey = new ShardKey\
+            \ { Keyword = \"shard_key\", } }\n);\n"
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.delete_shard_key("{collection_name}", "{shard_key}")
+
+            '
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::shard_key::Key;\nuse qdrant_client::qdrant::DeleteShardKeyRequestBuilder;\n\
+            use qdrant_client::Qdrant;\n\nlet client = Qdrant::from_url(\"http://localhost:6334\"\
+            ).build()?;\n\nclient\n    .delete_shard_key(\n        DeleteShardKeyRequestBuilder::new(\"\
+            {collection_name}\")\n            .key(Key::Keyword(\"{shard_key}\".to_string())),\n\
+            \    )\n    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import static io.qdrant.client.ShardKeyFactory.shardKey;\n\nimport\
+            \ io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nimport io.qdrant.client.grpc.Collections.DeleteShardKey;\nimport io.qdrant.client.grpc.Collections.DeleteShardKeyRequest;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.deleteShardKeyAsync(DeleteShardKeyRequest.newBuilder()\n\
+            \                .setCollectionName(\"{collection_name}\")\n         \
+            \       .setRequest(DeleteShardKey.newBuilder()\n                    \
+            \            .setShardKey(shardKey(\"{shard_key}\"))\n               \
+            \                 .build())\n                .build()).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteShardKey() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.DeleteShardKey(context.Background(),\
+            \ \"{collection_name}\", &qdrant.DeleteShardKey{\n\t\tShardKey: qdrant.NewShardKey(\"\
+            {shard_key}\"),\n\t})\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/shards/delete'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"shard_key\": \"{shard_key}\"\
+            \n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({\n    host: \"localhost\",\n    port: 6333\n\
+            });\n\nclient.deleteShardKey(\"{collection_name}\", {\n    shard_key:\
+            \ \"{shard_key}\"\n});\n"
+          language: typescript
+  /collections/{collection_name}/shards/{shard_id}/snapshots:
+    get:
+      description: Returns a list of all snapshots for a shard from a collection.
+      summary: List all snapshots (shard)
+      tags:
+      - Snapshots
+    post:
+      description: Creates a new snapshot of a shard from a collection.
+      summary: Create a snapshot (shard)
+      tags:
+      - Snapshots
+  /collections/{collection_name}/shards/{shard_id}/snapshots/recover:
+    put:
+      description: Recovers the shard of a local collection from a snapshot. This
+        will overwrite any collection data, which is stored in this shard.
+      summary: Recover from a snapshot (shard)
+      tags:
+      - Snapshots
+  /collections/{collection_name}/shards/{shard_id}/snapshots/upload:
+    post:
+      description: Recovers the shard of a local collection from an uploaded snapshot.
+        This will overwrite any collection data, which is stored in this shard.
+      summary: Recover from an uploaded snapshot (shard)
+      tags:
+      - Snapshots
+  /collections/{collection_name}/shards/{shard_id}/snapshots/{snapshot_name}:
+    delete:
+      description: Deletes the specified snapshot of a shard from a collection.
+      summary: Delete a snapshot (shard)
+      tags:
+      - Snapshots
+    get:
+      description: Downloads the specified snapshot of a shard from a collection as
+        a file.
+      summary: Download a snapshot (shard)
+      tags:
+      - Snapshots
+  /collections/{collection_name}/snapshots:
+    get:
+      description: Retrieves a list of all snapshots for a specified collection.
+      summary: List all snapshots (collection)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ListSnapshotsAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.list_snapshots(collection_name="{collection_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.list_snapshots("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.listSnapshotAsync(\"{collection_name}\"\
+            ).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc listSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListSnapshots(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Snapshots: \", snapshots)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/collections/collection_name/snapshots'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.listSnapshots("{collection_name}");
+
+            '
+          language: typescript
+    post:
+      description: Creates a new snapshot for a specified collection.
+      summary: Create a snapshot (collection)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.CreateSnapshotAsync("{collection_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.create_snapshot(collection_name="{collection_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.create_snapshot("{collection_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createSnapshotAsync(\"{collection_name}\"\
+            ).get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc createSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateSnapshot(context.Background(),\
+            \ \"{collection_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"\
+            Snapshot created: \", snapshot.Name)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/snapshots'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.createSnapshot("{collection_name}");
+
+            '
+          language: typescript
+  /collections/{collection_name}/snapshots/recover:
+    put:
+      description: Recovers local collection data from a snapshot. This will overwrite
+        any collection data stored on the node. If the collection does not exist,
+        it will be created.
+      summary: Recover from a snapshot (collection)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.recover_snapshot(\n    \"{collection_name}\"\
+            ,\n    \"http://example.com/path/to/snapshot.shapshot\",\n)\n"
+          language: python
+      - code-samples:
+        - code: "curl  -X PUT \\\n  'http://localhost:6333/collections/collection_name/snapshots/recover'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --header 'Content-Type:\
+            \ application/json' \\\n  --data-raw '{\n  \"location\": \"http://example.com/path/to/snapshot.shapshot\"\
+            \n}'"
+          language: curl
+      - code-samples:
+        - code: "import { QdrantClient } from \"@qdrant/js-client-rest\";\n\nconst\
+            \ client = new QdrantClient({ host: \"localhost\", port: 6333 });\n\n\
+            client.recoverSnapshot(\"{collection_name}\", {\n  location: \"http://example.com/path/to/snapshot.shapshot\"\
+            ,\n});\n"
+          language: typescript
+  /collections/{collection_name}/snapshots/upload:
+    post:
+      description: Recovers local collection data from an uploaded snapshot. This
+        will overwrite any collection data stored on the node. If the collection does
+        not exist, it will be created.
+      summary: Recover from an uploaded snapshot (collection)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/collections/collection_name/snapshots/upload'\
+            \ \\\n  --header 'api-key: <api-key-value>' \\\n  --form 'snapshot=@/path/to/snapshot.shapshot'"
+          language: curl
+  /collections/{collection_name}/snapshots/{snapshot_name}:
+    delete:
+      description: Deletes the specified snapshot for a collection.
+      summary: Delete a snapshot (collection)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeleteSnapshotAsync("{collection_name}", "{snapshot_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: "from qdrant_client import QdrantClient\n\nclient = QdrantClient(url=\"\
+            http://localhost:6333\")\n\nclient.delete_snapshot(\n    collection_name=\"\
+            {collection_name}\", snapshot_name=\"{snapshot_name}\"\n)\n"
+          language: python
+      - code-samples:
+        - code: "use qdrant_client::qdrant::DeleteSnapshotRequestBuilder;\nuse qdrant_client::Qdrant;\n\
+            \nlet client = Qdrant::from_url(\"http://localhost:6334\").build()?;\n\
+            \nclient\n    .delete_snapshot(DeleteSnapshotRequestBuilder::new(\n  \
+            \      \"{collection_name}\",\n        \"{snapshot_name}\",\n    ))\n\
+            \    .await?;\n"
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.deleteSnapshotAsync(\"{collection_name}\"\
+            , \"{snapshot_name}\").get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.DeleteSnapshot(context.Background(),\
+            \ \"{collection_name}\", \"{snapshot_name}\")\n\tif err != nil {\n\t\t\
+            panic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X DELETE \\\n  'http://localhost:6333/collections/collection_name/snapshots/snapshot_name'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.deleteSnapshot("{collection_name}", "{snapshot_name}");
+
+            '
+          language: typescript
+    get:
+      description: Downloads the specified snapshot file from a collection.
+      summary: Download a snapshot (collection)
+      tags:
+      - Snapshots
+  /healthz:
+    get:
+      description: Checks the health of individual instance.
+      summary: Kubernetes health check
+      tags:
+      - Service
+  /issues:
+    delete:
+      description: Removes all issues reported so far.
+      summary: Clear issues
+      tags:
+      - Beta
+    get:
+      description: Retrieves a report of performance issues and configuration suggestions.
+      summary: Report issues
+      tags:
+      - Beta
+  /livez:
+    get:
+      description: Monitors the container responsiveness and alerts in case of failure.
+      summary: Kubernetes liveness probe
+      tags:
+      - Service
+  /locks: {}
+  /metrics:
+    get:
+      description: 'Collect metrics data, such as: application info, collection info,
+        cluster info and statistics.'
+      summary: Collect Prometheus metrics data
+      tags:
+      - Service
+  /readyz:
+    get:
+      description: Checks the instance to see when it can start accepting traffic.
+      summary: Kubernetes readiness probe
+      tags:
+      - Service
+  /snapshots:
+    get:
+      description: Returns a list of all snapshots for the entire storage.
+      summary: List all snapshots (storage)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.ListFullSnapshotsAsync();
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.list_full_snapshots()
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.list_full_snapshots().await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.listFullSnapshotAsync().get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc listFullSnapshots() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsnapshots, err := client.ListFullSnapshots(context.Background())\n\
+            \tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Full snapshots:\
+            \ \", snapshots)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X GET \\\n  'http://localhost:6333/snapshots' \\\n  --header\
+            \ 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.listFullSnapshots();
+
+            '
+          language: typescript
+    post:
+      description: Creates a new snapshot of the entire storage.
+      summary: Create a snapshot (storage)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.CreateFullSnapshotAsync();
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.create_full_snapshot()
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.create_full_snapshot().await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.createFullSnapshotAsync().get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc createFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\tsnapshot, err := client.CreateFullSnapshot(context.Background())\n\
+            \tif err != nil {\n\t\tpanic(err)\n\t}\n\tfmt.Println(\"Snapshot created:\
+            \ \", snapshot.Name)\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X POST \\\n  'http://localhost:6333/snapshots' \\\n  --header\
+            \ 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.createFullSnapshot();
+
+            '
+          language: typescript
+  /snapshots/{snapshot_name}:
+    delete:
+      description: Deletes the specified snapshot of the entire storage.
+      summary: Delete a snapshot (storage)
+      tags:
+      - Snapshots
+      x-fern-examples:
+      - code-samples:
+        - code: 'using Qdrant.Client;
+
+
+            var client = new QdrantClient("localhost", 6334);
+
+
+            await client.DeleteFullSnapshotAsync("{snapshot_name}");
+
+            '
+          language: csharp
+      - code-samples:
+        - code: 'from qdrant_client import QdrantClient
+
+
+            client = QdrantClient(url="http://localhost:6333")
+
+
+            client.delete_full_snapshot(snapshot_name="{snapshot_name}")
+
+            '
+          language: python
+      - code-samples:
+        - code: 'use qdrant_client::Qdrant;
+
+
+            let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+
+            client.delete_full_snapshot("{snapshot_name}").await?;
+
+            '
+          language: rust
+      - code-samples:
+        - code: "import io.qdrant.client.QdrantClient;\nimport io.qdrant.client.QdrantGrpcClient;\n\
+            \nQdrantClient client = new QdrantClient(\n                QdrantGrpcClient.newBuilder(\"\
+            localhost\", 6334, false).build());\n\nclient.deleteFullSnapshotAsync(\"\
+            {snapshot_name}\").get();\n"
+          language: java
+      - code-samples:
+        - code: "package client\n\nimport (\n\t\"context\"\n\n\t\"github.com/qdrant/go-client/qdrant\"\
+            \n)\n\nfunc deleteFullSnapshot() {\n\tclient, err := qdrant.NewClient(&qdrant.Config{\n\
+            \t\tHost: \"localhost\",\n\t\tPort: 6334,\n\t})\n\tif err != nil {\n\t\
+            \tpanic(err)\n\t}\n\n\terr = client.DeleteFullSnapshot(context.Background(),\
+            \ \"{snapshot_name}\")\n\tif err != nil {\n\t\tpanic(err)\n\t}\n}\n"
+          language: go
+      - code-samples:
+        - code: "curl  -X DELETE \\\n  'http://localhost:6333/snapshots/snapshot_name'\
+            \ \\\n  --header 'api-key: <api-key-value>'"
+          language: curl
+      - code-samples:
+        - code: 'import { QdrantClient } from "@qdrant/js-client-rest";
+
+
+            const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+
+            client.deleteFullSnapshot("{snapshot_name}");
+
+            '
+          language: typescript
+    get:
+      description: Downloads the specified snapshot of the entire storage as a file.
+      summary: Download a snapshot (storage)
+      tags:
+      - Snapshots
+  /telemetry:
+    get:
+      description: 'Collects telemetry data, such as: application info, system info,
+        collection info, cluster info, configs and statistics.'
+      summary: Collect telemetry data
+      tags:
+      - Service

--- a/fern/apis/v1.18.x/openapi.json
+++ b/fern/apis/v1.18.x/openapi.json
@@ -7071,7 +7071,7 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "master"
+    "version": "v1.18.x"
   },
   "externalDocs": {
     "description": "Find out more about Qdrant applications and demo",

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -3,6 +3,8 @@ instances:
     custom-domain: api.qdrant.tech
 title: Qdrant | API Reference
 versions:
+  - display-name: v1.18.x
+    path: ./versions/v1.18.x.yml
   - display-name: v1.17.x
     path: ./versions/v1.17.x.yml
   - display-name: v1.16.x

--- a/fern/versions/v1.18.x.yml
+++ b/fern/versions/v1.18.x.yml
@@ -1,0 +1,9 @@
+navigation:
+  - api: API Reference
+    api-name: v1.18.x
+    summary: ../pages/api-summary.mdx
+    paginated: true
+
+
+
+          


### PR DESCRIPTION
## Summary

GitHub will force all JavaScript-based actions to run on Node 24 starting **June 2, 2026**.
Node 20 will be removed from runners entirely on September 16, 2026.

Actions pinned to older versions (v1-v4 for checkout, v2-v5 for setup-python, etc.) were
written for Node 12/16/20 and risk breaking when forced to Node 24.

This PR updates all `actions/*` references to the latest Node 24-native versions.

## Changes

| Action | From | To | Node |
|--------|------|----|------|
| actions/checkout | v1-v4 | v6.0.2 | 24 |
| actions/setup-python | v2-v5 | v6.2.0 | 24 |
| actions/setup-node | v2-v4 | v6.4.0 | 24 |
| actions/setup-go | v4-v5 | v6.4.0 | 24 |
| actions/setup-java | v3 | v5.2.0 | 24 |
| actions/setup-dotnet | v4 | v5.2.0 | 24 |
| actions/cache | v3-v4 | v5.0.5 | 24 |
| actions/upload-artifact | v4 | v7.0.1 | 24 |
| actions/download-artifact | v4-v5 | v8.0.1 | 24 |
| actions/github-script | v7 | v9.0.0 | 24 |

All target SHAs verified against their tags via the GitHub API.
All target versions confirmed running `node24` in their `action.yml`.

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/