### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Sync Docs
         run: |
           bash -x tools/sync-openapi.sh
-      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "Sync OpenAPI"
           commit_user_name: "GitHub Actions"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Sync Docs
         run: |
           bash -x tools/sync-openapi.sh
-      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "Sync OpenAPI"
           commit_user_name: "GitHub Actions"

--- a/fern/apis/master/openapi.json
+++ b/fern/apis/master/openapi.json
@@ -14958,7 +14958,7 @@
           {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 1
           },
           {
             "$ref": "#/components/schemas/ReadConsistencyType"


### PR DESCRIPTION
Update all third-party GitHub Actions to Node 24-compatible versions before the June 2 deadline.